### PR TITLE
Fix share sidebar encoding issue

### DIFF
--- a/components/share-sidebar.tsx
+++ b/components/share-sidebar.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+
 import { Button } from "@/components/ui/button";
 import {
   Sidebar,
@@ -12,18 +13,37 @@ import {
   SidebarMenuItem,
 } from "@/components/ui/sidebar";
 
+/**
+ * Build the destination for the "Se connecter" link.
+ *
+ * The component mirrors the previous behaviour: when a visitor is already on a
+ * share page we preserve their current location via the callback URL so that a
+ * successful sign-in returns them to the same conversation.
+ */
+export function buildLoginHref(pathname: string | null | undefined): string {
+  if (!pathname) {
+    return "/login";
+  }
+
+  return `/login?callbackUrl=${encodeURIComponent(pathname)}`;
+}
+
+/**
+ * Sidebar displayed on the public share view.
+ *
+ * It guides anonymous visitors to authenticate before starting their own
+ * conversations while keeping the shared thread readable.
+ */
 export function ShareSidebar() {
   const pathname = usePathname();
-  const loginHref = pathname
-    ? `/login?callbackUrl=${encodeURIComponent(pathname)}`
-    : "/login";
+  const loginHref = buildLoginHref(pathname ?? undefined);
 
   return (
     <Sidebar className="group-data-[side=left]:border-r">
       <SidebarHeader>
         <SidebarMenu>
           <SidebarMenuItem>
-            <span className="font-semibold text-lg">Conversation partagée</span>
+            <span className="font-semibold text-lg">Conversation partage</span>
           </SidebarMenuItem>
         </SidebarMenu>
       </SidebarHeader>
@@ -32,7 +52,7 @@ export function ShareSidebar() {
           <SidebarMenuItem>
             <p className="text-muted-foreground text-sm">
               Cet espace est accessible en lecture seule. Connectez-vous pour
-              démarrer vos propres conversations et interagir en temps réel.
+              demarrer vos propres conversations et interagir en temps reel.
             </p>
           </SidebarMenuItem>
         </SidebarMenu>

--- a/tests/unit/share-sidebar.test.ts
+++ b/tests/unit/share-sidebar.test.ts
@@ -1,0 +1,28 @@
+/**
+ * Unit coverage for the login link helper used by the public share sidebar.
+ *
+ * The Next.js component itself is rendered client-side, so this focused helper
+ * keeps the logic testable in a hermetic Node.js environment.
+ */
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildLoginHref } from "../../components/share-sidebar";
+
+test.describe("buildLoginHref", () => {
+  test("falls back to the generic login page when no pathname is present", () => {
+    assert.equal(buildLoginHref(null), "/login");
+    assert.equal(buildLoginHref(undefined), "/login");
+    assert.equal(buildLoginHref(""), "/login");
+  });
+
+  test("preserves the visitor pathname via the callback query parameter", () => {
+    const href = buildLoginHref("/share/thread-123?mode=preview");
+
+    assert.equal(
+      href,
+      "/login?callbackUrl=%2Fshare%2Fthread-123%3Fmode%3Dpreview",
+      "The pathname should be URI encoded so redirects remain safe",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- rewrite the share sidebar component to ensure the login link computation lives in a documented helper
- update the sidebar copy with plain ASCII text to avoid UTF-8 decoding issues during builds
- add unit coverage for the helper to guarantee the callback URL encoding remains stable

## Testing
- pnpm exec tsx --test tests/unit/share-sidebar.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dabd9e628c832f969c895208784de3