### PR TITLE
Share Playwright in-memory store across module graphs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,13 +15,13 @@ Voici ta **liste de tâches exhaustive**, agent. Elle est calée sur la **derni�
 ## Plan de correction (2025-10-30)
 
 1. **Finance – artefacts backtest**
-   * Vérifier que la requête backtest renvoie bien un unique artefact `finance-backtest-artifact`.
-   * Corriger les doublons/absences en garantissant une clé stable et un rendu conditionnel explicite.
-   * Couvrir le scénario par un test ciblé (composant ou route) validant l’unicité et la disponibilité de la table des trades.
+   * [x] Vérifier que la requête backtest renvoie bien un unique artefact `finance-backtest-artifact`.
+   * [x] Corriger les doublons/absences en garantissant une clé stable et un rendu conditionnel explicite.
+   * [x] Couvrir le scénario par un test ciblé (composant ou route) validant l’unicité et la disponibilité de la table des trades.
 2. **Chat – réédition de message**
-   * Inspecter le flux `editMessage` pour s’assurer que la réponse assistant est propagée après modification.
-   * Sécuriser la logique de streaming côté client et côté test helper (`ChatPage.waitForChatApiResponse`).
-   * Ajouter une couverture test (unit ou integration) pour éviter une régression silencieuse.
+   * [x] Inspecter le flux `editMessage` pour s’assurer que la réponse assistant est propagée après modification.
+   * [x] Sécuriser la logique de streaming côté client et côté test helper (`ChatPage.waitForChatApiResponse`).
+   * [ ] Ajouter une couverture test (unit ou integration) pour éviter une régression silencieuse.
 3. **Session – enregistrement utilisateur**
    * Diagnostiquer pourquoi la création d’un compte ne redirige plus vers `/chat`.
    * Harmoniser la réponse du handler `register` et l’attente Playwright (toast + redirection).
@@ -294,3 +294,4 @@ Si tu veux un lot de **patchs diff prêts à coller** pour les fichiers clés (`
 - **2025-10-29** — Introduction d’un schéma discriminant pour les artefacts persistés (`lib/artifacts/types.ts`), branchement de `convertToUIMessages` sur la nouvelle union, exécution de `pnpm install --frozen-lockfile`, et ajout de tests Vitest couvrant le wrapper (`artifacts.types.spec.ts`, `messages.spec.tsx`, `ai/messages.spec.ts`).
 - **2025-10-30** — Harmonisation des journaux : ajout de `logInfo`, conservation des empreintes anonymisées dans les logs finance, mise à jour du seed Postgres pour émettre un journal structuré, et rafraîchissement des tests Vitest (`logging`, `finance.api-utils`, `db/seed`).
 - **2025-10-31** — Déduplication des artefacts finance côté `convertToUIMessages` et `components/messages`, ajout d’un hash déterministe pour éviter les doublons, écriture des tests ciblés (`tests/unit/ai/messages.spec.ts`, `tests/unit/components/messages.spec.tsx`) et exécution de `pnpm exec vitest run …` pour valider le comportement.
+- **2025-11-01** — Élimination des doublons de parts finance côté `components/messages`, ajout d’un test RTL couvrant le scénario de streaming et renforcement du helper Playwright (`isGenerationComplete`) pour attendre le retour d’un message assistant avant les assertions, puis exécution de `pnpm exec vitest run tests/unit/components/messages.spec.tsx`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,25 @@ Voici ta **liste de tâches exhaustive**, agent. Elle est calée sur la **derni�
 
 ---
 
+## Plan de correction (2025-10-30)
+
+1. **Finance – artefacts backtest**
+   * Vérifier que la requête backtest renvoie bien un unique artefact `finance-backtest-artifact`.
+   * Corriger les doublons/absences en garantissant une clé stable et un rendu conditionnel explicite.
+   * Couvrir le scénario par un test ciblé (composant ou route) validant l’unicité et la disponibilité de la table des trades.
+2. **Chat – réédition de message**
+   * Inspecter le flux `editMessage` pour s’assurer que la réponse assistant est propagée après modification.
+   * Sécuriser la logique de streaming côté client et côté test helper (`ChatPage.waitForChatApiResponse`).
+   * Ajouter une couverture test (unit ou integration) pour éviter une régression silencieuse.
+3. **Session – enregistrement utilisateur**
+   * Diagnostiquer pourquoi la création d’un compte ne redirige plus vers `/chat`.
+   * Harmoniser la réponse du handler `register` et l’attente Playwright (toast + redirection).
+   * Vérifier via test E2E ciblé ou test API que la redirection est assurée.
+
+---
+
+---
+
 ## 0) Préparation & nettoyage (local)
 
 * [ ] Supprime les résidus d’anciennes runs : `.next/`, `node_modules/`, `playwright-report/`, `playwright-results/`.
@@ -274,3 +293,4 @@ Si tu veux un lot de **patchs diff prêts à coller** pour les fichiers clés (`
 - **2025-10-28** — Ajout d’un override testable pour masquer les artefacts finance côté Messages, journalisation explicite des artefacts filtrés, et correction du handler NextAuth credentials pour bannir l’usage de `any`; couverture Vitest mise à jour (`messages.spec.tsx`).
 - **2025-10-29** — Introduction d’un schéma discriminant pour les artefacts persistés (`lib/artifacts/types.ts`), branchement de `convertToUIMessages` sur la nouvelle union, exécution de `pnpm install --frozen-lockfile`, et ajout de tests Vitest couvrant le wrapper (`artifacts.types.spec.ts`, `messages.spec.tsx`, `ai/messages.spec.ts`).
 - **2025-10-30** — Harmonisation des journaux : ajout de `logInfo`, conservation des empreintes anonymisées dans les logs finance, mise à jour du seed Postgres pour émettre un journal structuré, et rafraîchissement des tests Vitest (`logging`, `finance.api-utils`, `db/seed`).
+- **2025-10-31** — Déduplication des artefacts finance côté `convertToUIMessages` et `components/messages`, ajout d’un hash déterministe pour éviter les doublons, écriture des tests ciblés (`tests/unit/ai/messages.spec.ts`, `tests/unit/components/messages.spec.tsx`) et exécution de `pnpm exec vitest run …` pour valider le comportement.

--- a/components/messages.tsx
+++ b/components/messages.tsx
@@ -5,6 +5,7 @@ import React, { Fragment, memo, useEffect, useRef } from "react";
 import { useMessages } from "@/hooks/use-messages";
 import type { Vote } from "@/lib/db/schema";
 import type { ChatMessage } from "@/lib/types";
+import { stableStringifyForHash } from "@/lib/utils";
 import { useDataStream } from "./data-stream-provider";
 import { Conversation, ConversationContent } from "./elements/conversation";
 import { Greeting } from "./greeting";
@@ -293,6 +294,8 @@ function PureMessages({
             }
 
             const invalidArtifacts: InvalidArtifactLog[] = [];
+            const seenArtifactKeys = new Set<string>();
+
             const sanitizedArtifacts: FinanceArtifact[] = financeFeatureEnabled
               ? artifactCandidates.reduce<FinanceArtifact[]>((acc, candidate, artifactIndex) => {
                   const parsed = parseFinanceArtifact(
@@ -303,10 +306,18 @@ function PureMessages({
                     candidate.typeHint
                   );
 
-                  if (parsed) {
-                    acc.push(parsed);
+                  if (!parsed) {
+                    return acc;
                   }
 
+                  const artifactFingerprint = `${parsed.type}:${stableStringifyForHash(parsed)}`;
+
+                  if (seenArtifactKeys.has(artifactFingerprint)) {
+                    return acc;
+                  }
+
+                  seenArtifactKeys.add(artifactFingerprint);
+                  acc.push(parsed);
                   return acc;
                 }, [])
               : [];

--- a/components/messages.tsx
+++ b/components/messages.tsx
@@ -255,6 +255,45 @@ function PureMessages({
              * finance payloads after we migrated the database representation to a
              * discriminated union.
              */
+            /**
+             * Deduplicate finance data parts before handing them to the
+             * renderer. Streaming may briefly surface both the transient
+             * artefact emitted during tool execution and the persisted payload
+             * saved once the assistant response completes. Comparing payload
+             * fingerprints avoids double-rendering the same finance panel while
+             * keeping other message parts untouched.
+             */
+            const seenFinancePartKeys = new Set<string>();
+            const deduplicatedParts = Array.isArray(message.parts)
+              ? message.parts.reduce<ChatMessage["parts"]>((acc, part) => {
+                  if (
+                    !part ||
+                    typeof part !== "object" ||
+                    typeof (part as { type?: unknown }).type !== "string"
+                  ) {
+                    acc.push(part);
+                    return acc;
+                  }
+
+                  const partType = (part as { type: string }).type;
+                  if (!partType.startsWith("data-finance")) {
+                    acc.push(part);
+                    return acc;
+                  }
+
+                  const payload = (part as { data?: unknown }).data;
+                  const fingerprint = `${partType}:${stableStringifyForHash(payload)}`;
+
+                  if (seenFinancePartKeys.has(fingerprint)) {
+                    return acc;
+                  }
+
+                  seenFinancePartKeys.add(fingerprint);
+                  acc.push(part);
+                  return acc;
+                }, [])
+              : [];
+
             const artifactCandidates: Array<{
               value: unknown;
               typeHint?: string;
@@ -270,31 +309,32 @@ function PureMessages({
               }
             }
 
-            if (Array.isArray(message.parts)) {
-              for (const part of message.parts) {
-                if (
-                  !part ||
-                  typeof part !== "object" ||
-                  !("type" in part) ||
-                  typeof part.type !== "string" ||
-                  !part.type.startsWith("data-finance")
-                ) {
-                  continue;
-                }
-
-                const dataCarrier = part as { data?: unknown };
-                const nested = dataCarrier.data;
-                const nestedType =
-                  typeof (nested as { type?: unknown })?.type === "string"
-                    ? ((nested as { type: string }).type as string)
-                    : undefined;
-
-                artifactCandidates.push({ value: nested, typeHint: nestedType });
+            for (const part of deduplicatedParts) {
+              if (
+                !part ||
+                typeof part !== "object" ||
+                typeof (part as { type?: unknown }).type !== "string"
+              ) {
+                continue;
               }
+
+              const partType = (part as { type: string }).type;
+              if (!partType.startsWith("data-finance")) {
+                continue;
+              }
+
+              const dataCarrier = part as { data?: unknown };
+              const nested = dataCarrier.data;
+              const nestedType =
+                typeof (nested as { type?: unknown })?.type === "string"
+                  ? ((nested as { type: string }).type as string)
+                  : undefined;
+
+              artifactCandidates.push({ value: nested, typeHint: nestedType });
             }
 
             const invalidArtifacts: InvalidArtifactLog[] = [];
-            const seenArtifactKeys = new Set<string>();
+            const seenArtifactKeys = new Set<string>(seenFinancePartKeys);
 
             const sanitizedArtifacts: FinanceArtifact[] = financeFeatureEnabled
               ? artifactCandidates.reduce<FinanceArtifact[]>((acc, candidate, artifactIndex) => {
@@ -338,6 +378,7 @@ function PureMessages({
             const normalisedMessage = {
               ...message,
               artifacts: sanitizedArtifacts,
+              parts: deduplicatedParts,
             } as ChatMessage;
 
             const invalidCount = financeFeatureEnabled ? invalidArtifacts.length : 0;

--- a/lib/db/queries.ts
+++ b/lib/db/queries.ts
@@ -287,6 +287,14 @@ function persistUsers(store: InMemoryStore) {
   }
 }
 
+declare global {
+  // eslint-disable-next-line no-var -- shared cache for the Playwright in-memory store.
+  var __ONCHARTV_IN_MEMORY_STORE__:
+    | InMemoryStore
+    | null
+    | undefined;
+}
+
 let inMemoryStore: InMemoryStore | null = null;
 
 /**
@@ -301,8 +309,13 @@ function getInMemoryStore(): InMemoryStore {
     );
   }
 
+  if (globalThis.__ONCHARTV_IN_MEMORY_STORE__) {
+    inMemoryStore = globalThis.__ONCHARTV_IN_MEMORY_STORE__ ?? null;
+  }
+
   if (!inMemoryStore) {
     inMemoryStore = getOrCreateInMemoryStore();
+    globalThis.__ONCHARTV_IN_MEMORY_STORE__ = inMemoryStore;
   }
 
   loadPersistedUsers(inMemoryStore);
@@ -345,6 +358,8 @@ export function __resetInMemoryDbForTests(): void {
   store.indicatorConfigs.clear();
   store.newsItems.clear();
   store.financePreferences.clear();
+
+  globalThis.__ONCHARTV_IN_MEMORY_STORE__ = store;
 
   try {
     if (fs.existsSync(PLAYWRIGHT_USERS_PATH)) {

--- a/lib/db/queries.ts
+++ b/lib/db/queries.ts
@@ -103,7 +103,10 @@ type InMemoryStore = {
 
 declare global {
   // eslint-disable-next-line no-var -- Explicitly extend the Node.js global scope.
-  var __ONCHARTV_IN_MEMORY_STORE__: InMemoryStore | undefined;
+  var __ONCHARTV_IN_MEMORY_STORE__:
+    | InMemoryStore
+    | null
+    | undefined;
 }
 
 type ProcessWithInMemoryStore = NodeJS.Process & {
@@ -285,14 +288,6 @@ function persistUsers(store: InMemoryStore) {
     // Persisting the hermetic credentials is best-effort; warn while redacting sensitive payloads.
     logWarning("db:queries", "Failed to persist Playwright users", { error });
   }
-}
-
-declare global {
-  // eslint-disable-next-line no-var -- shared cache for the Playwright in-memory store.
-  var __ONCHARTV_IN_MEMORY_STORE__:
-    | InMemoryStore
-    | null
-    | undefined;
 }
 
 let inMemoryStore: InMemoryStore | null = null;

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -39,6 +39,91 @@ const FALLBACK_PARSE_ERROR_MESSAGE =
 const FALLBACK_READ_ERROR_MESSAGE =
   'Unable to read the error response returned by the server.';
 
+/**
+ * Prefix applied to finance data parts injected into chat messages. Centralising
+ * the marker keeps downstream deduplication logic in sync with the renderers and
+ * avoids scattering string literals across the codebase.
+ */
+const FINANCE_DATA_PART_PREFIX = 'data-finance';
+
+/**
+ * Generate a deterministic string fingerprint for arbitrary JSON-like values.
+ *
+ * The helper recursively sorts object keys, guards against circular references
+ * via a `WeakSet`, and annotates primitive types to differentiate between values
+ * such as the number `1` and the string `'1'`.  Message artefact deduplication
+ * relies on this stable representation to detect duplicates originating from
+ * mixed persistence layers (legacy `message.artifacts` arrays and newer
+ * `data-finance*` parts streamed by the assistant).
+ */
+export function stableStringifyForHash(
+  value: unknown,
+  seen: WeakSet<object> = new WeakSet()
+): string {
+  if (value === null) {
+    return 'null';
+  }
+
+  const valueType = typeof value;
+
+  if (valueType === 'undefined') {
+    return 'undefined';
+  }
+
+  if (
+    valueType === 'number' ||
+    valueType === 'boolean' ||
+    valueType === 'bigint'
+  ) {
+    return `${valueType}:${String(value)}`;
+  }
+
+  if (valueType === 'string') {
+    return `string:${value}`;
+  }
+
+  if (valueType === 'symbol') {
+    return `symbol:${value.description ?? ''}`;
+  }
+
+  if (valueType === 'function') {
+    return 'function';
+  }
+
+  if (value instanceof Date) {
+    return `date:${value.toISOString()}`;
+  }
+
+  if (Array.isArray(value)) {
+    if (seen.has(value)) {
+      return '[Circular]';
+    }
+    seen.add(value);
+    const serialisedItems = value
+      .map((item) => stableStringifyForHash(item, seen))
+      .join(',');
+    return `array:[${serialisedItems}]`;
+  }
+
+  if (valueType === 'object') {
+    const objectValue = value as Record<string, unknown>;
+    if (seen.has(objectValue)) {
+      return '[Circular]';
+    }
+    seen.add(objectValue);
+    const serialisedEntries = Object.entries(objectValue)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(
+        ([key, entryValue]) =>
+          `${key}:${stableStringifyForHash(entryValue, seen)}`
+      )
+      .join(',');
+    return `object:{${serialisedEntries}}`;
+  }
+
+  return String(value);
+}
+
 function toChatSdkErrorFromEnvelope(
   envelope: ApiErrorEnvelope['error']
 ): ChatSDKError {
@@ -263,15 +348,46 @@ const artifactToDataPart = (
 
 export function convertToUIMessages(messages: DBMessage[]): ChatMessage[] {
   return messages.map((message) => {
-    const baseParts = message.parts as UIMessagePart<CustomUIDataTypes, ChatTools>[];
+    const baseParts = Array.isArray(message.parts)
+      ? (message.parts as UIMessagePart<CustomUIDataTypes, ChatTools>[])
+      : [];
+
     const artifactParts = (message.artifacts ?? [])
       .map(artifactToDataPart)
       .filter((part): part is UIMessagePart<CustomUIDataTypes, ChatTools> => part !== null);
 
+    const seenFinancePartKeys = new Set<string>();
+
+    const registerFinancePart = (
+      part: UIMessagePart<CustomUIDataTypes, ChatTools>
+    ): boolean => {
+      if (!part || typeof part !== 'object') {
+        return true;
+      }
+
+      const partType = typeof part.type === 'string' ? part.type : null;
+      if (!partType || !partType.startsWith(FINANCE_DATA_PART_PREFIX)) {
+        return true;
+      }
+
+      const payload = (part as { data?: unknown }).data;
+      const fingerprint = `${partType}:${stableStringifyForHash(payload)}`;
+
+      if (seenFinancePartKeys.has(fingerprint)) {
+        return false;
+      }
+
+      seenFinancePartKeys.add(fingerprint);
+      return true;
+    };
+
+    const dedupedBaseParts = baseParts.filter(registerFinancePart);
+    const dedupedArtifactParts = artifactParts.filter(registerFinancePart);
+
     return {
       id: message.id,
       role: message.role as 'user' | 'assistant' | 'system',
-      parts: [...baseParts, ...artifactParts],
+      parts: [...dedupedBaseParts, ...dedupedArtifactParts],
       metadata: {
         createdAt: formatISO(message.createdAt),
       },

--- a/tests/pages/chat.ts
+++ b/tests/pages/chat.ts
@@ -489,6 +489,15 @@ export class ChatPage {
     );
 
     /**
+     * Inline edit submissions temporarily clear the trailing assistant reply
+     * before the regeneration begins streaming. Ensure a fresh assistant
+     * bubble is attached before continuing so downstream helpers never observe
+     * an empty timeline (which previously triggered "No assistant message"
+     * errors in the Playwright harness).
+     */
+    await expect(assistantMessages).not.toHaveCount(0, { timeout: 60_000 });
+
+    /**
      * The assistant stream reuses the same container while piping tool results
      * into the UI. By the time we reach this section the guard above has either
      * observed a brand-new bubble or detected fresh content within the latest

--- a/tests/unit/ai/messages.spec.ts
+++ b/tests/unit/ai/messages.spec.ts
@@ -110,6 +110,35 @@ describe("convertToUIMessages", () => {
     expect(uiMessage.metadata.createdAt).toEqual(formatISO(createdAt));
   });
 
+  it("évite de dupliquer les data parts finance déjà présentes", () => {
+    const createdAt = new Date("2025-03-01T09:30:00Z");
+    const backtest = buildBacktestArtifact();
+
+    const message: DBMessage = {
+      id: "msg-duplicate", 
+      chatId: "chat-dup", 
+      role: "assistant",
+      parts: [
+        { type: "text", text: "Résultats du backtest" },
+        { type: "data-financeBacktest", data: backtest },
+      ],
+      attachments: [],
+      artifacts: [{ type: backtest.type, payload: backtest }],
+      createdAt,
+    } as DBMessage;
+
+    const [uiMessage] = convertToUIMessages([message]);
+
+    const financeParts = uiMessage.parts.filter(
+      (part) => part.type === "data-financeBacktest"
+    );
+
+    expect(financeParts).toHaveLength(1);
+    expect(financeParts[0]).toEqual(
+      expect.objectContaining({ data: backtest })
+    );
+  });
+
   it("ignore les artefacts finance invalides en loggant un avertissement", () => {
     const warnSpy = vi
       .spyOn(logging, "logWarning")

--- a/tests/unit/components/messages.spec.tsx
+++ b/tests/unit/components/messages.spec.tsx
@@ -315,6 +315,89 @@ describe("Messages", () => {
     expect(latestInvocation?.message?.artifacts).toEqual([backtestPayload]);
   });
 
+  it("déduplique les artefacts finance présents à la fois dans parts et artifacts", () => {
+    vi.stubEnv("NEXT_PUBLIC_FEATURE_FINANCE", "true");
+
+    const artifact: FinanceBacktestArtifact = {
+      type: "finance.backtest",
+      runId: "dedupe-1",
+      symbol: "NVDA",
+      timeframe: "1D",
+      period: { from: "2024-01-01", to: "2024-06-30" },
+      strategy: {
+        type: "sma-crossover",
+        params: { fastPeriod: 10, slowPeriod: 30 },
+      },
+      metrics: {
+        totalReturn: 0.12,
+        cagr: 0.18,
+        maxDrawdown: 0.08,
+        winRate: 0.55,
+        averageWin: 3200,
+        averageLoss: -1400,
+        sharpe: 1.1,
+        profitFactor: 1.8,
+        trades: 6,
+      },
+      equityCurve: [{ t: 1704067200, e: 10_000 }],
+      trades: [
+        {
+          entryTimestamp: 1704067200,
+          entryPrice: 450,
+          exitTimestamp: 1706745600,
+          exitPrice: 470,
+          quantity: 2,
+          grossPnl: 40,
+          netPnl: 38,
+        },
+      ],
+      commentary: "dedupe payload",
+    };
+
+    const message = {
+      id: "assistant-dedupe",
+      role: "assistant",
+      metadata: { createdAt: new Date().toISOString() },
+      parts: [
+        { id: "text", type: "text", text: "Analyse du backtest" },
+        { type: "data-financeBacktest", data: artifact },
+      ],
+      artifacts: [
+        {
+          type: "finance.backtest",
+          payload: artifact,
+        },
+      ],
+    } as unknown as ChatMessage;
+
+    render(
+      <Messages
+        chatId="chat-finance"
+        isArtifactVisible={false}
+        isReadonly={false}
+        messages={[message]}
+        regenerate={noop as any}
+        selectedModelId="model"
+        setMessages={noop as any}
+        status="idle"
+        votes={undefined}
+      />,
+      { wrapper: Wrapper }
+    );
+
+    const latestInvocation = previewMessageSpy.mock.calls.at(-1)?.[0] as
+      | { message?: ChatMessage }
+      | undefined;
+
+    expect(latestInvocation?.message?.artifacts).toEqual([artifact]);
+
+    const financeParts = latestInvocation?.message?.parts?.filter(
+      (part) => part.type === "data-financeBacktest"
+    );
+
+    expect(financeParts).toHaveLength(1);
+  });
+
   it("affiche les messages valides et ignore les votes manquants", () => {
     const message = {
       id: "msg-1",

--- a/tests/unit/components/messages.spec.tsx
+++ b/tests/unit/components/messages.spec.tsx
@@ -398,6 +398,83 @@ describe("Messages", () => {
     expect(financeParts).toHaveLength(1);
   });
 
+  it("filtre les doublons de parts finance injectés pendant le streaming", () => {
+    vi.stubEnv("NEXT_PUBLIC_FEATURE_FINANCE", "true");
+
+    const artifact: FinanceBacktestArtifact = {
+      type: "finance.backtest",
+      runId: "streamed-duplicate",
+      symbol: "NVDA",
+      timeframe: "4H",
+      period: { from: "2024-02-01", to: "2024-03-01" },
+      strategy: {
+        type: "sma-crossover",
+        params: { fastPeriod: 12, slowPeriod: 26 },
+      },
+      metrics: {
+        totalReturn: 0.08,
+        cagr: 0.11,
+        maxDrawdown: 0.05,
+        winRate: 0.6,
+        averageWin: 1100,
+        averageLoss: -500,
+        sharpe: 0.9,
+        profitFactor: 1.5,
+        trades: 5,
+      },
+      equityCurve: [{ t: 1706745600, e: 10_000 }],
+      trades: [
+        {
+          entryTimestamp: 1706745600,
+          entryPrice: 410,
+          exitTimestamp: 1707436800,
+          exitPrice: 418,
+          quantity: 3,
+          grossPnl: 24,
+          netPnl: 22,
+        },
+      ],
+      commentary: "duplicate parts should collapse",
+    };
+
+    const messageWithDuplicateParts = {
+      id: "assistant-streaming-dedupe",
+      role: "assistant",
+      metadata: { createdAt: new Date().toISOString() },
+      parts: [
+        { id: "text", type: "text", text: "Streaming backtest" },
+        { type: "data-financeBacktest", data: artifact, transient: true },
+        { type: "data-financeBacktest", data: { ...artifact } },
+      ],
+      artifacts: [],
+    } as unknown as ChatMessage;
+
+    render(
+      <Messages
+        chatId="chat-finance"
+        isArtifactVisible={false}
+        isReadonly={false}
+        messages={[messageWithDuplicateParts]}
+        regenerate={noop as any}
+        selectedModelId="model"
+        setMessages={noop as any}
+        status="idle"
+        votes={undefined}
+      />,
+      { wrapper: Wrapper }
+    );
+
+    const latestInvocation = previewMessageSpy.mock.calls.at(-1)?.[0] as
+      | { message?: ChatMessage }
+      | undefined;
+
+    const financeParts = latestInvocation?.message?.parts?.filter(
+      (part) => part.type === "data-financeBacktest"
+    );
+
+    expect(financeParts).toHaveLength(1);
+  });
+
   it("affiche les messages valides et ignore les votes manquants", () => {
     const message = {
       id: "msg-1",

--- a/tests/unit/db/queries.spec.ts
+++ b/tests/unit/db/queries.spec.ts
@@ -75,6 +75,40 @@ describe("finance queries", () => {
     queries = reloadedQueries;
   });
 
+  it("shares transient chat messages across module reloads", async () => {
+    const chatId = "module-reload-chat";
+    const createdAt = new Date("2024-02-01T00:00:00.000Z");
+
+    await queries.saveMessages({
+      messages: [
+        {
+          id: "user-reload",
+          chatId,
+          role: "user",
+          parts: [{ type: "text", text: "Initial prompt" }],
+          attachments: [],
+          artifacts: [],
+          createdAt,
+        },
+      ],
+    });
+
+    let messages = await queries.getMessagesByChatId({ id: chatId });
+    expect(messages).toHaveLength(1);
+
+    vi.resetModules();
+    vi.mock("server-only", () => ({}));
+
+    const reloadedQueries = await import("../../../lib/db/queries");
+    messages = await reloadedQueries.getMessagesByChatId({ id: chatId });
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]?.id).toBe("user-reload");
+
+    reloadedQueries.__resetInMemoryDbForTests();
+    queries = reloadedQueries;
+  });
+
   it("allows credentials verification after failed attempts refresh the user hash", async () => {
     const email = "playwright-flow@example.com";
     const password = "deterministic-secret";


### PR DESCRIPTION
## Summary
- cache the Playwright in-memory database on the global object so server actions and route handlers share state
- keep the cache pointer in sync when resetting during tests
- cover the behaviour with a module-reload unit test for chat messages

## Testing
- pnpm exec vitest run tests/unit/db/queries.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68f38cf72b04832fb198c4088fcbed64