### PR TITLE
Stabilize chat identifier normalisation updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,68 +1,55 @@
-# Agent Brief — reset 2025-12-09
+# Agent Brief — reset 2025-12-12
 
 ## Context
-The latest `pnpm e2e` run (2025-12-09) exposed two blocking regressions in addition to the previously failing edit flows:
-- **Chat activity › Send a user message and receive response** — No assistant messages ever appear (`data-testid="message-assistant"` count remains 0), so even the first chat send stalls.
-- **chat activity with reasoning › Curie can edit message and resubmit** — The polling assertion still captures the pre-edit assistant reply instead of the refreshed answer.
+The most recent `pnpm e2e` run (2025-12-12) now passes the baseline chat send but still reports three blocking flows:
+- **Chat activity › Edit user message and resubmit** – the assistant reply never updates after editing; the DOM continues to show the pre-edit "green" answer.
+- **Finance end-to-end journeys › streams a BTCUSD chart and exposes interactive controls** – the finance conversation never surfaces an assistant bubble (`data-testid="message-assistant"` count stays at 0).
+- **Login and Registration › Register new account** – after registration the dashboard loads without a visible composer, so the poll for `.prompt-composer` times out.
 
-Accessibility, finance, registration, and other chat scenarios now pass, so the remaining scope is focused on restoring assistant message rendering and edit resiliency.
+Other finance and reasoning paths are currently green, so effort should focus on restoring assistant rendering in tool-heavy chats and keeping the composer visible for fresh accounts.
 
 ## Objectives
-- Restore deterministic streaming behaviour after editing chat messages for both standard and reasoning conversations.
-- Ensure the reasoning transcript helpers observe the refreshed assistant output after an edit.
-- Guarantee that a newly registered account lands on an interactive chat (composer visible, chat id present).
-- Keep the Playwright auth warm-up and storage state reuse intact while iterating on the fixes above.
+- Ensure assistant messages persist (and render) after finance tool execution so Playwright can observe chart replies.
+- Make standard chat edits emit a refreshed assistant response while preserving the existing reasoning success case.
+- Guarantee new registrations always land on a chat with a visible composer, even if the session refresh lags.
+- Keep recently added diagnostics intact to speed up further Playwright debugging.
 
 ## Task Checklist
 
-### 1. Assistant message regression (baseline send fails)
-- [ ] Reproduce the missing assistant bubble locally (focus the "Send a user message and receive response" test) and inspect the DOM to confirm whether the assistant block fails to mount or is immediately removed. *(still blocked — browsers installed but `playwright install-deps` pulls ~500 MB of packages; run once the environment budget allows)*
-- [x] Trace the message rendering pipeline (`components/messages.tsx`, `lib/chat/message-status.ts`, `lib/ai/providers.ts`) to ensure assistant messages remain in the array after edits and that status derivation does not filter them out.
-- [x] Add unit coverage (ideally in `tests/unit/components/message*.spec.tsx`) that asserts assistant messages render when the provider returns a response without a `status` field.
-- [x] Patch the chat surface (`components/chat.tsx`) to synthesise stable identifiers as soon as streamed assistant messages land and emit diagnostics for every fallback.
-- [x] Guard synthetic identifier generation when `metadata.createdAt` is missing so the renderer never throws while streaming transient payloads.
-- [x] Refine identifier normalisation to mutate the existing message collection unless objects are non-extensible, and add unit coverage for the cloned-array fallback.
-- [x] Guard the identifier normalisation effect against stale snapshots by funnelling updates through `setMessages` functional setters.
-- [ ] Run `pnpm exec playwright test tests/e2e/chat.test.ts -g "Send a user message and receive response"` and keep the passing trace for reference. *(2025-12-12 — intermittent: first rerun under `PLAYWRIGHT_STREAM_DEBUG=1` passed once, subsequent attempt regressed with zero assistant messages; latest local attempt fails earlier because Playwright browsers are missing — install via `pnpm exec playwright install` before the next rerun.)*
+### 1. Finance assistant bubble regression
+- [ ] Re-run the focused Playwright spec once browsers/deps are installed: `pnpm exec playwright test tests/e2e/finance.spec.ts -g "streams a BTCUSD chart"`.
+- [ ] Inspect `ChatPage.waitForUiStreamingFallback` logs and the stream debug snapshots to confirm whether assistant messages remain in state during finance tool runs.
+- [ ] Audit `lib/ai/providers.ts` and downstream reducers to ensure tool completions append an assistant turn (rather than only tool artifacts).
+- [ ] Add unit coverage around the finance mock/tool transcript to guarantee an assistant summary is emitted after the chart data resolves.
+- [ ] Re-run the focused Playwright test and archive the passing trace.
 
-### 2. Chat edit/resubmit streaming
-- [ ] Verify that whatever fix restores baseline assistant rendering also re-enables the edit flow; if not, instrument `ChatPage.waitForUiStreamingFallback` to log the message ids and statuses it observes.
-- [ ] Ensure the updated message state triggers a `streaming → complete` transition on edits, updating both helper logic and component props as needed.
-- [ ] Extend the existing Vitest coverage to include an edit scenario where the assistant response arrives without explicit status flags.
-- [ ] Re-run `pnpm exec playwright test tests/e2e/chat.test.ts -g "Edit user message and resubmit"` and archive the trace on success.
+### 2. Chat edit/resubmit (standard conversations)
+- [ ] Use the stream debug output to verify the message statuses transition from `streaming` to `complete` after an edit-triggered resend.
+- [ ] Confirm `resolveLatestRelevantMessage` (or equivalent helper) selects the edited user turn before invoking the provider.
+- [ ] Add Vitest coverage that simulates editing a message followed by a provider response lacking explicit status metadata.
+- [ ] Re-run `pnpm exec playwright test tests/e2e/chat.test.ts -g "Edit user message and resubmit"` and capture the passing trace.
 
-### 3. Reasoning edit/resubmit expectations
-- [ ] Confirm how `ChatPage.getRecentAssistantMessage` filters reasoning turns and adjust it to fetch the latest assistant content after edits.
-- [x] Align the reasoning mock provider (if applicable) so that re-issued prompts return updated reasoning steps plus the final answer.
-- [ ] Extend `tests/e2e/reasoning.test.ts` with stronger polling (or helper assertions) that validate the message actually changes.
-- [ ] Re-run `pnpm exec playwright test tests/e2e/reasoning.test.ts -g "Curie can edit message and resubmit"` to validate.
+### 3. Registration composer visibility
+- [ ] Trace the post-registration redirect to ensure a chat id is present in both the URL and client-side state.
+- [ ] Update the client onboarding hook/page so the composer renders while session validation is pending.
+- [ ] Extend unit or integration tests to assert the composer is visible immediately after a successful registration.
+- [ ] Re-run `pnpm exec playwright test tests/e2e/session.test.ts -g "Register new account"` and inspect the trace for composer presence.
 
-### 4. Registration composer visibility
-- [x] Instrument the registration action/page to log the redirect target and the created chat id when running under `PLAYWRIGHT=true`.
-- [x] Ensure the server-side registration flow creates or fetches a chat and returns a redirect to `/chat/:id`.
-- [ ] Update the client-side onboarding hook so the composer mounts even if the session refresh is still in flight.
-- [x] Add coverage (unit or integration) proving a freshly registered user sees an enabled composer.
-- [ ] Re-run `pnpm exec playwright test tests/e2e/session.test.ts -g "Register new account"` and inspect the trace for the composer state.
+### 4. Playwright readiness & diagnostics
+- [ ] Install Playwright browsers and (if allowed) `playwright install-deps` so local reruns no longer skip due to missing binaries.
+- [ ] Keep `PLAYWRIGHT_STREAM_DEBUG=1` available for targeted runs and clean up logging once the regressions are fixed.
 
 ## Validation Matrix
-Run the following once all fixes are applied:
-1. `pnpm exec vitest run tests/unit/ai/providers.spec.ts tests/unit/pages/chat-page.spec.ts`
+Run these once the fixes above are complete:
+1. `pnpm exec vitest run tests/unit/ai/providers.spec.ts tests/unit/components/chat.spec.tsx`
 2. `pnpm exec playwright test tests/e2e/chat.test.ts -g "Edit user message and resubmit"`
-3. `pnpm exec playwright test tests/e2e/reasoning.test.ts -g "Curie can edit message and resubmit"`
+3. `pnpm exec playwright test tests/e2e/finance.spec.ts -g "streams a BTCUSD chart"`
 4. `pnpm exec playwright test tests/e2e/session.test.ts -g "Register new account"`
 5. `pnpm e2e`
 
 ## Handoff Notes
-- Keep `DEBUG=playwright` handy for additional instrumentation; traces from the failing runs live under `playwright-results/` with matching names.
-- Avoid modifying the Playwright storage state schema unless necessary; current runs regenerate credentials when missing.
-- Document any new instrumentation directly in the relevant module comments so future agents can disable it cleanly.
-- 2025-12-08 — Introduced `lib/ai/prompt-helpers.ts` so both the inline mocks and the production provider select the freshest user/tool prompt, and updated `tests/prompts/utils.spec.ts`/`tests/unit/ai/providers.spec.ts` accordingly. Registration flow now logs seeded chat ids under Playwright and prefers the seeded redirect over the generic `/chat` fallback; added unit coverage for both success branches. Targeted Vitest suites pass (`ai/providers`, prompts, auth actions) but `tests/unit/pages/chat-page.spec.ts` repeatedly exhausted the container (SIGKILL) and the focused Playwright edit test still stalls with zero assistant messages; traces saved under `playwright-results/e2e-chat-Chat-activity-Edit-user-message-and-resubmit-e2e/` for investigation.
-- 2025-12-09 — Added `lib/chat/message-status.ts` to derive deterministic assistant statuses and rewired `components/messages.tsx` to consume it so inline edits always surface a `streaming` flag. Introduced `tests/unit/components/messages.status.spec.ts` to cover the fallback logic. Targeted edit Playwright run still times out because no assistant bubble ever reattaches (`message-assistant` count stays at 0); inspect the latest trace under `playwright-results/e2e-chat-Chat-activity-Edit-user-message-and-resubmit-e2e/` for DOM + network clues.
-- 2025-12-10 — Latest full `pnpm e2e` run shows baseline chat send now fails (no assistant messages rendered) while the reasoning edit resubmit still returns the pre-edit answer. Accessibility and registration flows pass. Focus next steps on restoring assistant message rendering and updating reasoning polling once baseline chat behaviour is recovered. Relevant traces: `playwright-results/e2e-chat-Chat-activity-Sen-83c51-essage-and-receive-response-e2e/` and `playwright-results/e2e-reasoning-chat-activit-c5759-n-edit-message-and-resubmit-e2e/`.
-- 2025-12-11 — Normalised message hydration in `components/messages.tsx` to tolerate missing `parts` arrays and emit targeted diagnostics, added `tests/unit/components/messages.render.spec.tsx` to lock in the regression fix, and started the Playwright browser/dependency installs so targeted chat runs can execute locally (still downloading system packages — rerun the focused chat test once the install completes).
-- 2025-12-11 — Synthesised fallback message identifiers in `components/messages.tsx` so assistant bubbles render even when the SDK omits `id`, added unit coverage for the synthetic-id path, and attempted to run the focused chat Playwright test. Browsers are now installed but the shared container lacks the desktop dependencies (`playwright install-deps` tries to fetch ~500 MB); rerun the e2e check once the host allows the package install.
-- 2025-12-11 — Added `lib/chat/message-identifiers.ts` with helpers shared by `components/chat.tsx` and `components/messages.tsx` so streamed assistant replies receive deterministic ids before rendering. Patched the chat component to log each synthesised identifier and wrote `tests/unit/lib/chat.message-identifiers.spec.ts` to lock the behaviour before rerunning targeted renderer tests. Playwright checks remain blocked until the container installs the browser dependencies.
-- 2025-12-12 — Hardened the identifier helper against absent metadata timestamps, added regression coverage, and reran the focused chat Playwright test (still failing with zero assistant messages despite the guard; see latest trace under `playwright-results/e2e-chat-Chat-activity-Sen-83c51-essage-and-receive-response-e2e/`).
-- 2025-12-12 — Instrumented the chat surface and mock provider with stream-aware diagnostics, then reran `pnpm exec playwright test tests/e2e/chat.test.ts -g "Send a user message and receive response"` under `PLAYWRIGHT_STREAM_DEBUG=1`. The first rerun passed but the follow-up attempt still timed out with zero assistant bubbles; keep the new debug hooks while triaging the remaining regressions.
-- 2025-12-12 — Updated `lib/chat/message-identifiers.ts` to retain the existing message array when possible (only cloning when messages are frozen), adjusted `components/chat.tsx` to reuse that signal, and expanded the identifier unit suite accordingly. Focused `pnpm exec playwright test … "Send a user message and receive response"` still times out in the `beforeEach` navigation after ~4 minutes, so baseline assistant rendering remains unresolved.
-- 2025-12-12 — Channelled the identifier normalisation effect through the functional `setMessages` updater to avoid overriding newer chat payloads, introduced `prepareNormalisedMessageUpdate` for reuse, and extended the identifier tests to cover the new helper. Targeted Playwright chat run is still pending because the shared container lacks installed browsers (`pnpm exec playwright install` required).
+- Keep `DEBUG=playwright` handy; failing traces live in `playwright-results/` with descriptive names.
+- Finance traces without assistant bubbles: `playwright-results/e2e-finance-Finance-end-to-2ebe4-xposes-interactive-controls-e2e/`.
+- Edit-resubmit traces capturing the stale "green" reply: `playwright-results/e2e-chat-Chat-activity-Edit-user-message-and-resubmit-e2e/`.
+- Registration traces where the composer stays hidden: `playwright-results/e2e-session-Login-and-Registration-Register-new-account-e2e/`.
+- 2025-12-12 — Baseline send now succeeds; outstanding work is limited to finance assistant rendering, standard edit refreshes, and registration composer visibility. Diagnostics for message ids/status remain in place.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,424 +1,68 @@
-Voici ta **liste de tâches exhaustive**, agent. Elle est calée sur la **dernière version du code** que je viens d’auditer et sur nos analyses précédentes (causes d’échecs E2E principales : overlay Next suite à exception client, et divergence d’auth). Les tâches sont **opérationnelles**, **hiérarchisées**, et **précisées fichier par fichier**. Les objectifs et critères d’acceptation (Definition of Done) sont inclus à chaque bloc.
-
----
-
-## BRIEF — objectifs à atteindre (par toi, l’agent)
-
-* Supprimer toute **exception client** qui déclenche l’overlay Next sur les écrans Chat/Finance.
-* **Unifier l’auth** en **mode regular-only** et **aligner les E2E** avec un **storage state** déjà authentifié.
-* Rendre les **E2E déterministes** : mocks complets `/api/finance/*`, **horloge gelée**, **bypass rate-limit** sous `PLAYWRIGHT=true`.
-* Uniformiser les **erreurs API** (`{ error: { code, message } }`) et les **validations Zod** sur toutes les routes finance.
-* Verrouiller **build/CI** : migrations idempotentes, `engines.node`, variables d’env, healthcheck dev-server, artefacts de tests.
-
----
-
-## Plan de correction (2025-10-30)
-
-1. **Finance – artefacts backtest**
-   * [x] Vérifier que la requête backtest renvoie bien un unique artefact `finance-backtest-artifact`.
-   * [x] Corriger les doublons/absences en garantissant une clé stable et un rendu conditionnel explicite.
-   * [x] Couvrir le scénario par un test ciblé (composant ou route) validant l’unicité et la disponibilité de la table des trades.
-2. **Chat – réédition de message**
-   * [x] Inspecter le flux `editMessage` pour s’assurer que la réponse assistant est propagée après modification.
-   * [x] Sécuriser la logique de streaming côté client et côté test helper (`ChatPage.waitForChatApiResponse`).
-   * [x] Ajouter une couverture test (unit ou integration) pour éviter une régression silencieuse.
-3. **Session – enregistrement utilisateur**
-   * [x] Diagnostiquer pourquoi la création d’un compte ne redirige plus vers `/chat`.
-   * [x] Harmoniser la réponse du handler `register` et l’attente Playwright (toast + redirection).
-   * [x] Vérifier via test E2E ciblé ou test API que la redirection est assurée.
-
----
-
-## Plan de correction complémentaire (2025-11-08)
-
-Objectif : éliminer les trois échecs Playwright toujours présents dans les logs CI du 2025-11-08 (`finance artefacts accessibility`, `chat edit/resubmit`, `register new account`). Chaque lot précise le diagnostic attendu, les investigations à mener et le livrable de validation.
-
-1. **Finance — accessibilité des artefacts backtest**
-   * [ ] Rejouer localement `tests/e2e/accessibility.spec.ts` en mode `DEBUG=playwright` et capturer le DOM juste après `GET /api/finance/backtest` pour confirmer l’absence de `<div data-testid="finance-backtest-artifact">` (utiliser `page.screenshot` + `console.debug` côté serveur dans `lib/ai/messages/convertToUIMessages`).
-      - Tentative du 2025-12-01 : l'exécution isolée a échoué dans le `beforeEach` (timeout 240 s) avec fermeture du contexte avant l'apparition du bouton `send-button`. Le dev-server restait accessible mais la navigation `/chat` n'a jamais terminé la préparation de la surface; trace disponible dans `playwright-results/e2e-accessibility-Finance--f2112-ls-across-finance-artefacts-e2e/`.
-  * [x] Cartographier le pipeline de rendu :
-      - [x] Inspecter `lib/ai/messages.ts` et `convertToUIMessages` pour l’état des `data-finance-backtest` parts après la déduplication par hash.
-      - [x] Vérifier dans `components/messages.tsx` (sections `financePartFingerprints` et `sanitizedArtifacts`) quelles branches peuvent vider `artifactCandidates` lorsque plusieurs payloads identiques sont reçus.
-      - [x] Examiner `components/finance/backtest-report-artifact.tsx` afin de confirmer les conditions de rendu/aria (`hidden`, `aria-hidden`, `tabIndex`).
-  * [x] Corriger la condition fautive (ordre de filtre, hash incorrect ou gating `financeFeatureEnabled`) de sorte qu’au moins un artefact backtest persiste et possède un `table` focusable ; ajouter un test React Testing Library (réalisé via `BacktestReportArtifact`) qui vérifie `getByTestId("finance-backtest-artifact")` + focus sur le tableau.
-  * [x] Instrumenter la normalisation côté `Messages` pour journaliser les candidats d'artefacts écartés (2025-11-23).
-  * [x] Emettre un snapshot `[convertToUIMessages]` via `console.debug` lorsque `DEBUG` contient `playwright` afin de tracer les artefacts (2025-11-28).
-  * [x] Normaliser les bornes de période `finance.backtest` (coercition ISO + mocks alignés) pour éviter la purge silencieuse des artefacts lorsque l'API renvoie des epochs (2025-11-30).
-  * [ ] Rejouer `tests/e2e/accessibility.spec.ts` isolé pour valider que l’artefact est visible, puis archiver la capture `trace.zip` associée dans les notes CI.
-      - Tentative du 2025-12-01 : l'exécution isolée a échoué dans le `beforeEach` (timeout 240 s) avec fermeture du contexte avant l'apparition du bouton `send-button`. Le dev-server restait accessible mais la navigation `/chat` n'a jamais terminé la préparation de la surface; trace disponible dans `playwright-results/e2e-accessibility-Finance--f2112-ls-across-finance-artefacts-e2e/`.
-      - Tentative du 2025-12-02 : `DEBUG=playwright pnpm exec playwright test tests/e2e/accessibility.spec.ts --reporter=dot` échoue toujours faute d'artefact backtest visible (`getByTestId("finance-backtest-artifact")` absent). Les logs côté dev-server signalent des erreurs JWT (`no matching decryption secret`) lors de la réutilisation du storage state ainsi qu'un `SyntaxError: Unexpected end of JSON input` après 100 s d'attente de la surface chat. Trace conservée sous `playwright-results/e2e-accessibility-Finance--f2112-ls-across-finance-artefacts-e2e/`.
-      - Mise à jour du 2025-12-03 : correction de la boucle `pollForStreamingChange` (accolade manquante) qui empêchait la compilation des helpers Playwright/Vitest (`Unexpected token` dans `tests/pages/chat.ts`). Relancer les suites ciblées maintenant que le parseur ne bloque plus.
-
-2. **Chat — réédition et redémarrage du streaming**
-  * [x] Ajouter une instrumentation dans `tests/pages/chat.ts` (via `logPlaywrightStreamDebug` et horodatage) autour de `prepareForGeneration`, `waitForUiStreamingFallback` et `pollForStreamingChange` pour observer les valeurs `assistantCount`, `signalCount`, `spinnerCount` pendant l’édition.
-  * [x] Comparer ces mesures avec les événements côté client : instrumenter `components/chat.tsx` et `components/messages.tsx` (flag `PLAYWRIGHT_STREAM_DEBUG`) pour journaliser la succession `pending → streaming → completed` et détecter si le SSE `token` s’arrête avant que `messages` soit réhydraté.
-  * [x] Adapter la logique `pollForStreamingChange` : vérifier la prise en compte des états `spinnerCount === 0` mais `assistantCount === baseline.count` en présence d’un message avec `latestMessageId` identique ; considérer l’écoute de `data-message-status="streaming"` ou du compteur `__PLAYWRIGHT_CHAT_SIGNALS__`.
-  * [x] Ajouter un test ciblé (Vitest jsdom dans `tests/unit/pages/chat-page.spec.ts`) qui valide qu’un changement de `data-message-status` déclenche bien la reprise du streaming lors d’une édition.
-  * [x] Capturer l’état observé lors du timeout (`pollForStreamingChange`) et l’ajouter aux journaux/erreurs pour diagnostiquer les blocages Playwright (2025-11-26) — relancer `tests/e2e/chat.test.ts:83` une fois le dev-server stable.
-  * [ ] Rejouer `tests/e2e/chat.test.ts:83` avec `DEBUG=pw:api` pour confirmer la disparition du timeout, puis supprimer les journaux temporaires.
-
-3. **Session — inscription utilisateur et redirection**
-  * [ ] Exécuter `tests/e2e/session.test.ts:56` seul en conservant le `trace.zip` et relever :
-      - Tentative du 2025-12-04 (`pnpm exec playwright test tests/e2e/session.test.ts --project=e2e --grep "Register new account"`).
-        Après installation des dépendances système/browsers (`pnpm exec playwright install chromium` + `install-deps`),
-        l’auth setup aboutit, la surface chat finit par se charger (73.7 s) mais `waitForChatDashboard`
-        reste bloqué sur `http://localhost:44313/register`. Trace stockée sous
-        `playwright-results/e2e-session-Login-and-Registration-Register-new-account-e2e/trace.zip` pour analyse
-        (réponse finale attendue / toasts encore à inspecter via l’outil trace).
-      - [ ] la réponse de l’action `/register` (`network` tab) et le payload JSON retourné,
-      - [ ] les éventuels toasts ou erreurs de validation dans la console.
-  * [x] Limiter la tentative de `updateSession()` à 3s côté client avant de lancer `router.replace` pour éviter les blocages Playwright (2025-11-10).
-  * [x] Durcir `waitForChatDashboard` en pollant le composer pour absorber les transitions client lentes après redirection (2025-11-13).
-  * [x] Remplacer l’assertion directe sur le champ email par un `expect.poll` dans `ensureLoggedIn` afin d’absorber les désynchronisations de rendu pendant l’hydratation (2025-11-15).
-  * [x] Vérifier côté serveur (`app/(auth)/register/page.tsx`, `app/(auth)/register/actions.ts`) que le flux crée un chat initial via `createInitialChat`, invalide les routes `/chat` et `/chat/:id`, et renvoie un `redirectTo` ciblant la nouvelle conversation (2025-11-17). Contrôler la cohérence avec `tests/setup/auth.setup.ts` (callbacks `onRegenerated`).
-  * [x] Introduire, si nécessaire, un mécanisme client pour garantir l’apparition du composer après succès (fallback `window.location.assign` lancé après `router.replace`, couvert par `register-page.spec.tsx`).
-  * [x] Lancer `router.replace` dès la fin du rafraîchissement de session afin que la navigation `/chat` démarre avant l’expiration de la fenêtre toast (2025-11-22).
-  * [x] Instrumenter `app/(auth)/register/page.tsx` pour journaliser la phase de redirection et forcer un double `window.location.*` (250 ms + 750 ms) en complément du `router.replace`, puis couvrir le comportement via `register-page.spec.tsx`.
-    * [ ] Rejouer `tests/e2e/session.test.ts:56` et vérifier que `waitForChatDashboard` voit bien `getByPlaceholder("Send a message...")` dans les 60s ; si besoin, ajuster le helper pour attendre la création du premier chat (`expect.poll` sur `message-assistant`).
-        - Constat du 2025-11-18 : la route `/api/auth/callback/credentials` renvoie encore un `302` malgré `redirect=false`, ce qui fait expirer `loginWithCredentialsCallback`; diagnostiquer `NextAuth`/handler avant la prochaine tentative.
-        - Mise à jour du 2025-11-19 : le helper Playwright plafonne désormais les redirections (`maxRedirects: 0`) et applique un chemin par défaut lors de l’injection des cookies, à valider lors de la prochaine relance ciblée.
-        - Mise à jour du 2025-11-20 : normaliser l’URL injectée (origine → `new URL(...).toString()`), logguer un avertissement ciblé si la normalisation échoue, puis relancer le setup Playwright isolé pour confirmer la disparition de l’erreur « Cookie should have either url or path ».
-        - Mise à jour du 2025-11-21 : `didSignInSucceed` considère désormais les réponses `3xx` non orientées vers `/login` comme des succès, ce qui reflète les retours NextAuth observés en CI (validé via `node --import tsx --test tests/unit/auth-sign-in-response.test.ts`).
-        - Mise à jour du 2025-11-24 : normalisation de l'injection des cookies Playwright (`tests/setup/auth.setup.ts`) avec logging structuré et filtrage des métadonnées pour diagnostiquer les erreurs `addCookies`, à valider lors de la prochaine relance ciblée.
-        - Mise à jour du 2025-11-25 : retrait du slash final et de la propriété `path` lors de l'injection des cookies dans le contexte Playwright pour éviter l'erreur « Cookie should have either url ou path », couvert par `tests/unit/helpers/create-auth-context.spec.ts` et `tests/unit/utils/programmatic-login.spec.ts`.
-        - Mise à jour du 2025-11-27 : double `setTimeout` (250 ms / 750 ms) et fallback `window.location` instrumenté dans `register/page.tsx`, logs `[register] enforcing window-level redirect` visibles en jsdom ; la relance Playwright ciblée continue toutefois d'échouer (composer non visible), `trace.zip` à analyser lors de la prochaine session.
-        - Mise à jour du 2025-11-29 : appel immédiat de `ensureHardRedirect()` juste après `router.replace` pour amorcer la navigation avant les timeouts, validé par `tests/unit/components/auth/register-page.spec.tsx`.
-
-4. **Validation finale**
-   * [ ] Exécuter `pnpm exec playwright test tests/e2e/accessibility.spec.ts tests/e2e/chat.test.ts:83 tests/e2e/session.test.ts:56` (ou les blocs équivalents) jusqu’à obtenir un résultat vert.
-   * [ ] Relancer `pnpm e2e` complet et archiver les principales statistiques (`[#timing]`, captures en cas d’échec) pour le journal CI.
-
-**Notes**
-
-- Les captures Playwright existantes (voir `playwright-results/...`) restent utiles pour comparer l’avant/après.
-- Prioriser la reproductibilité locale avant de modifier les composants : ajouter des logs `console.debug` temporaires si nécessaire, mais les supprimer avant le commit final.
-
----
-
-
-## 0) Préparation & nettoyage (local)
-
-* [ ] Supprime les résidus d’anciennes runs : `.next/`, `node_modules/`, `playwright-report/`, `playwright-results/`.
-* [x] Réinstalle et rebâtis : `pnpm install` puis `pnpm build`.
-  **DoD** : build local OK, pas d’erreurs TypeScript.
-
----
-
-## 1) Auth — option **B (regular-only)** et cohérence bout-en-bout
-
-* [x] `app/(chat)/page.tsx`
-
-  * [x] Si pas de session **ou** `session.user.type !== "regular"` → **redirect `/login`** (comportement unique et documenté).
-* [x] `app/(chat)/api/chat/route.ts`
-
-  * [x] En cas de non-regular : **renvoyer** `403` avec payload **JSON** : `{ error: { code: "forbidden:chat", message: "Regular session required" } }`.
-  * [x] Aucune `throw` non capturée.
-* [ ] `tests/setup/auth.setup.ts`
-
-  * [x] Implémente un **register/login** fiable (sélecteurs exacts), **attends** la redirection vers `/chat`.
-  * [x] **Sauvegarde** le **storage state** et **réutilise-le** dans toutes les suites E2E.
-  * [x] (Nettoyage) Retire toute dépendance résiduelle aux parcours invités (`/api/auth/guest`) depuis les tests.
-  **DoD** : toute suite E2E démarre déjà **authentifiée**; plus aucun 403/redirect inattendu en E2E.
-
----
-
-## 2) Robustesse UI — **error boundary** & rendu défensif
-
-* [x] `app/(chat)/error.tsx` (à créer si absent)
-
-  * [x] **Error boundary** de segment : fallback clair (titre, explication, bouton “Réessayer”), `console.error(error)`.
-* [x] `components/finance/finance-chart-artifact.tsx`
-
-  * [x] **Créer** l’instance chart **une seule fois** (guard via `useRef`).
-  * [x] **Cleanup** complet au démontage : `unsubscribe` des handlers (click, crosshair), suppression des séries, `chart.remove()`.
-  * [x] **Null-checks** sur data : si `ohlcv.length === 0`, afficher un **empty state** et **ne pas** initialiser le chart.
-  * [x] **Ne jamais** accéder à des refs si le composant est démonté (flag `mountedRef`).
-  * [x] Vérifie/garantis les `data-testid` utilisés en E2E :
-
-    * [x] `finance-chart-artifact`
-    * [x] `finance-chart-details`
-* [x] `components/messages.tsx`
-
-  * [x] Utilise `(messages ?? [])` et `(artifacts ?? [])`.
-  * [x] Fallback visuel pour artefact inconnu/malformé (pas de `throw`).
-* [x] `components/chat.tsx`
-
-  * [x] Guards autour des contexts/stores pendant le streaming.
-  * [x] Pas d’accès DOM/ref avant montage.
-    **DoD** : plus **aucun overlay Next** visible en conditions de test; les interactions chart fonctionnent (clic/hover) sans exception.
-
----
-
-## 3) Rate-limit — **bypass E2E**
-
-* [x] `lib/ratelimit.ts`
-
-  * [x] Si `process.env.PLAYWRIGHT === "true"` → **autoriser** (pas de 429) ou multiplier sévèrement le quota.
-  * [x] Conserver la politique standard hors E2E.
-    **DoD** : pas de 429 durant les E2E; tests unitaires confirment que le bypass est **limité à E2E**.
-
----
-
-## 4) API Finance — validations & erreurs uniformes
-
-Pour **chaque** route :
-
-* [x] `app/api/finance/history/route.ts`
-
-  * [x] **Zod** strict (symbol, timeframe enum bornée, `from`/`to`, `limit`).
-  * [x] Cap `limit` (ex. ≤ 5000), normalise `from <= to`, fuseau OK.
-  * [x] **Erreurs** : `{ error: { code: "bad_request", message } }` + status (400/422).
-
-* [x] `app/api/finance/backtest/route.ts`
-
-  * [x] Zod strict pour la stratégie et les bornes.
-  * [x] Réponse : `metrics` (totalReturn, CAGR, maxDrawdown, winRate, sharpe, profitFactor), `equityCurve`, `trades`.
-  * [x] Erreurs uniformes (400/422), jamais d’exception brute.
-
-* [x] `app/api/finance/quote/route.ts`, `fundamentals/route.ts`, `news/route.ts`, `screen/route.ts`
-
-  * [x] Inputs validés (symbol requis, pagination et bornes).
-  * [x] Erreurs au même format `{ error: { code, message } }`.
-
-* [x] `lib/finance/data-adapter.ts`
-
-  * [x] Conversion centralisée (string→number, timestamps normalisés), tolérance aux valeurs manquantes/NaN.
-
-**DoD** : tous les tests unitaires **routes** passent, le format d’erreur est **identique** partout; aucune route ne jette d’exception non gérée.
-
----
-
-## 5) UI Finance — interactions & a11y
-
-* [x] `components/finance/finance-chart-artifact.tsx`
-
-  * [x] Toggling overlays (SMA/EMA) modifie réellement l’état des séries (mock chart pour tests).
-  * [x] `finance-chart-details` actualisé au survol/clic d’une bougie.
-
-* [x] `components/finance/backtest-report-artifact.tsx`
-
-  * [x] Table **a11y** (thead/th/aria-*), unités explicites.
-  * [x] Bouton “Re-tester” : validation client (Zod) sur les paramètres.
-
-* [x] `components/finance/fundamentals-card.tsx`, `components/finance/news-list.tsx`
-
-  * [x] Rendu **robuste** avec données partielles (placeholders, pas de crash).
-
-**DoD** : tests UI unitaires verts; E2E peuvent cliquer/attendre des états stables sans flaky.
-
----
-
-## 6) Backtest & indicateurs — cas limites
-
-* [x] `lib/finance/backtest/engine.ts`
-
-  * [x] **Zéro trade** : `winRate=0`, `profitFactor=0`, `maxDrawdown` calculé sur courbe plate; aucune division par 0.
-  * [x] **Fees/slippage** : calculs cohérents pour valeurs élevées.
-
-* [x] `lib/finance/indicators.ts`
-
-  * [x] EMA/RSI : bornes strictes, séries < fenêtre, séries constantes.
-
-* [x] `lib/finance/patterns.ts`
-
-  * [x] Non-détection sur bruit; détection stable sur fixtures (hammer/engulfing).
-
-**DoD** : tests unitaires **complets** sur ces cas limites (verts).
-
----
-
-## 7) E2E — stabilisation (finance + chat)
-
-* [x] `tests/setup/auth.setup.ts`
-
-  * [x] Exécute **register/login** une fois, **sauvegarde le storage state**, et réutilise-le.
-  * [x] Vérifie les **sélecteurs** et la redirection `/chat`.
-
-* [x] `tests/e2e/finance.spec.ts`
-
-  * [x] **Intercepte** toutes les routes `/api/finance/*` (history/quote/fundamentals/news/backtest/screen) avec fixtures **stables**.
-  * [x] **Gèle l’horloge** au démarrage.
-  * [x] Scénarios :
-
-    * [x] BTCUSD 1D + SMA(50/200) → clic bougie → **détails visibles**.
-    * [x] Toggling SMA/EMA → assertions visible/masqué.
-    * [x] Backtest SMA 50/200 AAPL → métriques + `equityCurve` + `trades`.
-    * [x] Fundamentals + 3 news NVDA → titres/dates visibles.
-
-* [x] `tests/e2e/accessibility.spec.ts`
-
-  * [x] Vérifie l’a11y des artefacts (table backtest, états vides lisibles), **sans** overlay Next.
-
-* [x] `tests/pages/chat.ts`
-
-  * [x] Mets à jour les **sélecteurs** (input, envoyer, items de message) si divergences.
-  * [x] Évite toute dépendance à des ressources externes (mock si besoin).
-
-**DoD** : tous les E2E **passent localement**; pas de timeouts; plus d’overlay Next dans les traces.
-
----
-
-## 8) CI / Build
-
-* [x] `.github/workflows/ci.yml`
-
-  * [x] Expose `PLAYWRIGHT: "true"` et `FEATURE_FINANCE: "true"`.
-  * [x] Ordre jobs : **db:migrate → db:seed → build → test (unit) → e2e**.
-  * [x] **Healthcheck** du dev-server avant e2e (200 attendu).
-  * [x] Upload artefacts : **Playwright report**, **trace.zip**, **coverage** Vitest.
-
-* [x] `package.json`
-
-  * [x] `"engines": { "node": ">=20.10" }`.
-  * [x] `packageManager` renseigné (ex. `pnpm@x.y.z`).
-  * [x] Scripts présents : `build`, `test`, `e2e`, `e2e:install`, `db:migrate`, `db:seed`.
-
-**DoD** : pipeline CI **vert** de bout en bout; artefacts accessibles.
-
----
-
-## 9) Base de données & seeds
-
-* [x] `lib/db/schema.ts`
-
-  * [x] Index & uniques pertinents (ex. `BacktestRun(assetId, timeframe, periodStart)`; `(symbol, exchange)` unique sur `Asset`).
-  * [x] FK + `onDelete` cohérentes (`Strategy` → `StrategyVersion` → `BacktestRun`).
-
-* [x] `lib/db/migrations/*.sql`
-
-  * [x] **Idempotentes** : re-jouables sans erreur.
-  * [x] À jour avec le schéma.
-
-* [x] `lib/db/seed.ts`
-
-  * [x] Jeux d’exemples (`AAPL`, `NVDA`, `BTCUSD`, `EURUSD`) alignés sur les **fixtures E2E**.
-
-**DoD** : migrations et seeds tournent en CI; données cohérentes avec les tests.
-
----
-
-## 10) ENV & Docs
-
-* [x] `.env.example`
-
-  * [x] Clés présentes : `OPENAI_API_KEY`, `OPENAI_MODEL_ID`, `FEATURE_FINANCE`, `MARKET_DATA_API_KEY`, `NEWS_API_KEY`, `POSTGRES_URL`.
-  * [x] Commentaires brefs (portée de chaque clé).
-
-* [x] `README.md`
-
-  * [x] **Disclaimer** (“Pas un conseil financier”).
-  * [x] Explications : flags `FEATURE_FINANCE`, `PLAYWRIGHT`, gel de l’horloge E2E, mocks, choix **regular-only**, et comment les tests s’appuient sur le storage state.
-
-**DoD** : onboarding clair; aucun test ne dépend d’un secret non documenté.
-
----
-
-## 11) Qualité & garde-fous
-
-* [x] Typage & Zod
-
-  * [x] Types inférés via `z.infer` (éviter `any`), union discriminée pour artefacts (clé `type`).
-* [x] Feature flag
-
-  * [x] `FEATURE_FINANCE` réellement pris en compte dans l’UI (masquage sections si désactivé).
-* [x] Logs
-
-  * [x] Pas de secrets/PII; niveaux `info/warn/error` pertinents; format concis.
-
-**DoD** : lint/tsc propres; logs propres; flags efficaces.
-
----
-
-## Validation finale
-
-* [ ] Local : `/chat` → “Montre BTCUSD 1D avec SMA(50/200)” → chart interactif **sans overlay**, détails au clic OK.
-* [x] `pnpm test` (unit) → **verts**.
-* [ ] `pnpm e2e` → **verts** (finance + accessibilité); traces **sans** “Application error: a client-side exception…”.
-* [ ] CI → **vert**; rapports et artefacts disponibles.
-
----
-
-## Points en suspens
-
-1. ✅ `pnpm build` relancé (log > `/tmp/build.log`) et succès confirmé via `tail -n 50 /tmp/build.log` le 2025-11-03.
-2. Les tests E2E restent à exécuter (`pnpm e2e`). Le setup nécessite que Playwright soit installé (fait via `pnpm exec playwright install --with-deps chromium`).
-3. Vérifier que les autres sections du plan (auth flow, finance E2E) sont toujours à l’état attendu.
-4. La suite complète `tests/unit/pages/chat-page.spec.ts` reste très lourde (OOM > 200s). Seule l’assertion ciblée "reconnaît le retour d'un message assistant recréé après une édition" a été rejouée pour valider la nouvelle couverture.
-
-## Tests complémentaires recommandés
-
-- [x] Ajouter un scénario couvrant un cache JSON incomplet dans `tests/unit/db/queries.spec.ts` (manquant jusqu’ici).
-- [x] Intégrer un test d’intégration Playwright qui corrompt `tests/.auth/user.json` pour valider la résilience de `loadCredentials()` (voir `tests/e2e/setup/credentials-resilience.test.ts`).
-
-## Informations utiles
-
-- Les nouvelles dépendances (`@tanstack/react-query`, `lightweight-charts`, etc.) ont été installées via `pnpm install`; ne pas réinitialiser `node_modules/`.
-- Tests unitaires déjà exécutés : `pnpm exec vitest run tests/unit/db/queries.spec.ts tests/unit/utils/load-credentials.spec.ts` et l’assertion ciblée de `tests/unit/pages/chat-page.spec.ts`.
-- Naviguer dans `tests/utils/load-credentials.ts` pour toute modification future côté setup Playwright.
-- `loadCredentials` accepte un callback `onRegenerated` pour nettoyer `state.json`/cookies lorsque le cache change : voir `tests/setup/auth.setup.ts`.
-
-## TODOs ciblés
-
-- [x] `tests/unit/db/queries.spec.ts`: vérifier si d’autres cas d’erreur (JSON mal formé non vide) doivent être couverts (lignes ~120-140).
-- [x] `tests/setup/auth.setup.ts`: confirmer que l’appel à `loadCredentials()` est correctement géré lors des reruns (aucune régression signalée, mais garder un œil sur les logs Playwright).
-- [x] Relancer `pnpm build` et archiver les 20 dernières lignes de sortie pour le compte-rendu CI (fait le 2025-11-03).
-
-## Problèmes / quirks connus
-
-- Le reset de la base mémoire (`__resetInMemoryDbForTests`) journalise un warning « Failed to reset persisted Playwright users » quand le fichier JSON n’existe pas : c’est attendu avec l’approche actuelle.
-- Les commandes Next.js génèrent énormément d’output ; utiliser une redirection vers fichier pour éviter les limites de taille dans ce sandbox.
-
-Si tu veux un lot de **patchs diff prêts à coller** pour les fichiers clés (`app/(chat)/error.tsx`, `app/(chat)/api/chat/route.ts`, `lib/ratelimit.ts`, `components/finance/finance-chart-artifact.tsx`, `tests/setup/auth.setup.ts`, et les routes finance), je te les fournis dans la foulée.
-
----
-
-## Historique des actions
-
-- **2025-10-17** — Ajout du helper `isChatPathname` pour fiabiliser la détection de la redirection `/chat` dans le setup Playwright, ajout d’un poll `expect` garantissant que la session authentifiée atterrit bien sur le tableau de bord chat, et création d’un test Vitest couvrant les cas acceptés/refusés.
-- **2025-10-18** — Vérification du bootstrap Playwright : validation de la persistance/recyclage du storage state partagé par les suites, purge des restes d'API invitées et mise à jour du journal des tâches pour refléter ces états.
-- **2025-10-19** — Durcissement du garde `/login` sur le segment racine chat avec réutilisation de session pré-authentifiée, alignement de l’import aliasé pour faciliter les tests, vérification du handler API régulier et ajout d’un test Vitest isolé validant les redirections et la délégation de rendu.
-- **2025-10-20** — Vérification approfondie de la robustesse UI : contrôle du fallback error boundary `(chat)`, audit du renderer du chart finance (instanciation unique, teardown complet, états vides, guards `mountedRef`), validation des fallbacks `components/messages` et des garde-fous de streaming dans `components/chat`, puis mise à jour du journal des tâches pour refléter ces accomplissements.
-- **2025-10-21** — Validation du bypass rate-limit Playwright : documentation du court-circuit dans `lib/ratelimit.ts`, ajout d’un test Vitest garantissant l’absence de fuite d’état lorsque le flag est désactivé, et mise à jour de la checklist pour clôturer la section.
-- **2025-10-22** — Harmonisation des routes finance : validations Zod complètes (history/backtest/quote/fundamentals/news/screen), format d’erreur `{ code, message }` généralisé via `ChatSDKError`, durcissement de l’adapter marché contre NaN, et exécution des suites `tests/unit/routes/finance.*` pour couvrir les régressions.
-- **2025-10-23** — Validation UI finance : renforcement du toggle des overlays (tests persistants, `aria-pressed` attendu), persistance des sélections de bougies et couverture Vitest du panneau de détails, introduction d’un schéma Zod client pour le formulaire de re-test avec messages localisés, et ajout de tests couvrant les bornes SMA/dates.
-- **2025-10-24** — Stabilisation E2E finance : clic clavier + souris sur le graphique Playwright avec vérification des overlays itératifs, assertions d’a11y (tableau journal, pagination, absence d’overlay Next) et journalisation des interceptions stables. Tentative de `pnpm exec playwright test …` interrompue par le module manquant `@tanstack/react-query` côté dev-server.
-- **2025-10-25** — Renforcement de la couche données finance : index unique `BacktestRun_asset_timeframe_period_unique`, migration idempotente associée, garde miroir dans l’ORM en mémoire et tests Vitest couvrant le rejet des doublons + vérification PGlite de l’index.
-- **2025-10-26** — Documentation et configuration Playwright : ajout des variables `PLAYWRIGHT` et `NEXT_PUBLIC_FEATURE_FINANCE` dans `.env.example`, rédaction d’une section README détaillant le mode regular-only (redirection `/login`, erreur 403 JSON, storage state Playwright), vérification de la pipeline CI et mise à jour de la checklist.
-- **2025-10-27** — Consolidation des cas limites finance : clamp explicite du drawdown plat dans `lib/finance/backtest/engine.ts`, couverture Vitest du scénario quantité nulle et des frais extrêmes, garde vide/period invalide pour les indicateurs EMA/RSI avec tests directionnels, et filtrage des patterns marteau/engulfing via une analyse de tendance pour éviter les faux positifs.
-- **2025-10-28** — Ajout d’un override testable pour masquer les artefacts finance côté Messages, journalisation explicite des artefacts filtrés, et correction du handler NextAuth credentials pour bannir l’usage de `any`; couverture Vitest mise à jour (`messages.spec.tsx`).
-- **2025-10-29** — Introduction d’un schéma discriminant pour les artefacts persistés (`lib/artifacts/types.ts`), branchement de `convertToUIMessages` sur la nouvelle union, exécution de `pnpm install --frozen-lockfile`, et ajout de tests Vitest couvrant le wrapper (`artifacts.types.spec.ts`, `messages.spec.tsx`, `ai/messages.spec.ts`).
-- **2025-10-30** — Harmonisation des journaux : ajout de `logInfo`, conservation des empreintes anonymisées dans les logs finance, mise à jour du seed Postgres pour émettre un journal structuré, et rafraîchissement des tests Vitest (`logging`, `finance.api-utils`, `db/seed`).
-- **2025-10-31** — Déduplication des artefacts finance côté `convertToUIMessages` et `components/messages`, ajout d’un hash déterministe pour éviter les doublons, écriture des tests ciblés (`tests/unit/ai/messages.spec.ts`, `tests/unit/components/messages.spec.tsx`) et exécution de `pnpm exec vitest run …` pour valider le comportement.
-- **2025-11-01** — Élimination des doublons de parts finance côté `components/messages`, ajout d’un test RTL couvrant le scénario de streaming et renforcement du helper Playwright (`isGenerationComplete`) pour attendre le retour d’un message assistant avant les assertions, puis exécution de `pnpm exec vitest run tests/unit/components/messages.spec.tsx`.
-- **2025-11-02** — Durcissement de l’hydratation Playwright : journal structuré pour les enregistrements incomplets, tests Vitest couvrant les caches vides/incomplets (`tests/unit/db/queries.spec.ts`, `tests/unit/utils/load-credentials.spec.ts`), et ajout d’une couverture ciblée de `ChatPage.waitForUiStreamingFallback` validée via `pnpm exec vitest run -t "reconnaît le retour" tests/unit/pages/chat-page.spec.ts`.
-- **2025-11-03** — Confirmation du correctif de déduplication finance (`components/messages.tsx`, `lib/utils.ts`), ajout du test jsdom d’inscription (`tests/unit/components/auth/register-page.spec.tsx`), exécution de `pnpm exec vitest run tests/unit/components/messages.spec.tsx tests/unit/components/auth/register-page.spec.tsx --reporter=basic`, puis relance réussie de `pnpm build` avec capture des 50 dernières lignes.
-- **2025-11-04** — Ajout d’un test Playwright résilience (`tests/e2e/setup/credentials-resilience.test.ts`) qui corrompt `tests/.auth/user.json`, vérifie la régénération via `loadCredentials()`, purge le snapshot `state.json`, et restaure le cache initial.
-- **2025-11-05** — Durcissement de `tests/setup/auth.setup.ts` : ajout du callback `onRegenerated` dans `loadCredentials`, purge automatique de `state.json` et du cookie Playwright lors d’un changement d’utilisateur, lecture de contrôle du cache et extension des tests unitaires (`tests/unit/utils/load-credentials.spec.ts`).
-- **2025-11-06** — Stabilisation du pont vers `lib/logging` : cache global tenant compte des `vi.spyOn`, ajustements de `loadPersistedUsers` pour réémettre les avertissements avec l’instance espionnée, et passage complet de `pnpm test` confirmant les cas JSON corrompus/incomplets (`tests/unit/db/queries*.spec.ts`).
-- **2025-11-07** — Restauration automatique du snapshot `state.json` après le test Playwright de résilience des identifiants afin que les suites routes/E2E retrouvent la session authentifiée, et assouplissement du détecteur de streaming (`tests/pages/chat.ts`) pour considérer les vidages de bulles assistants comme un signal valide. Vérifié via `pnpm exec vitest run tests/unit/utils/load-credentials.spec.ts --reporter=basic`.
-- **2025-11-08** — Analyse des échecs Playwright persistants (finance backtest a11y, chat edit/resubmit, register redirect) et élaboration d’un plan d’attaque détaillé avec étapes d’investigation, correctifs ciblés et validation finale.
-- **2025-11-09** — Raffinement du plan 2025-11-08 : ajout des sous-étapes de diagnostic (captures DOM, instrumentation Playwright/client, audit du flux register) et définition des validations par tests ciblés avant relance complète de `pnpm e2e`.
-- **2025-11-10** — Encapsulation de `updateSession()` côté register avec une course timeout 3s + Vitest ciblé pour éviter les blocages Playwright avant la redirection `/chat`.
-- **2025-11-11** — Stabilisation de la rehydratation finance : amélioration de `convertToUIMessages` pour remplacer les parts transitoires par les artefacts persistés, ajout d’un `tabIndex` documenté sur la table du journal des trades, et création de tests Vitest (`ai/messages`, `components/backtest-report-artifact`) garantissant la présence/focusabilité de l’artefact backtest.
-- **2025-11-12** — Ajout de l’attribut `data-message-status` sur les bulles assistant, adaptation de `waitForUiStreamingFallback` pour considérer l’état "streaming" lors des rééditions, et création d’un test jsdom ciblé validant le nouveau signal Playwright.
-- **2025-11-13** — Renforcement du helper `waitForChatDashboard` : utilisation d’un `expect.poll` sur le composer pour absorber les transitions lentes avant d’asserter la redirection `/chat`.
-- **2025-11-14** — Ajout d’un fallback de redirection stricte après inscription (`window.location.assign` temporisé), généralisation de `pollForStreamingChange` pour reconnaître les transitions d’état assistant, et création d’un test jsdom dédié couvrant ce changement de statut.
-- **2025-11-15** — Durcissement du setup Playwright : surveillance du champ email via `expect.poll` dans `ensureLoggedIn` pour tolérer l’hydratation lente et préparation à la relance de `tests/e2e/session.test.ts:56`.
-- **2025-11-16** — Centralisation du debug streaming Playwright : création de `lib/playwright-debug.ts`, instrumentation de `tests/pages/chat.ts`, `components/chat.tsx` et `components/messages.tsx` derrière le flag `PLAYWRIGHT_STREAM_DEBUG`, ajout d’un test RTL vérifiant la télémétrie, et exécution de `pnpm exec vitest run tests/unit/components/messages.spec.tsx --reporter=basic`.
-- **2025-11-17** — Semis d’un chat d’onboarding lors de l’inscription : ajout de `createInitialChat` dans `lib/db/queries.ts`, mise à jour de `register` pour invalider `/chat` et retourner le nouvel identifiant, couverture Vitest (`tests/unit/db/queries.spec.ts`) et actualisation du plan pour refléter le statut côté serveur.
-- **2025-11-18** — Correction du référentiel `messages` dans `components/chat.tsx` (initialisation du hook avant comptage), ajout d’une instrumentation Vitest garantissant que `logPlaywrightStreamDebug` voit bien `{ status, messageCount }`, et nouvelle tentative Playwright révélant le 302 persistant sur `/api/auth/callback/credentials`.
-- **2025-11-19** — Ajustement de `loginWithCredentialsCallback` pour bloquer les redirections implicites de NextAuth (`maxRedirects: 0`), normalisation des cookies injectés dans le contexte Playwright (`path` par défaut, repli `url`), et mise à jour du test unitaire `programmatic-login.spec.ts` confirmant l’option explicite.
-- **2025-11-20** — Normalisation de l’URL injectée dans `tests/setup/auth.setup.ts` (origin → `new URL(...).toString()`), avertissement ciblé si la conversion échoue, et exécution de `pnpm exec vitest run tests/unit/utils/programmatic-login.spec.ts --reporter=basic` pour vérifier le nouveau comportement.
-- **2025-11-21** — Alignement de `didSignInSucceed` sur les réponses 302 de NextAuth pour que la post-inscription reconnaisse les redirections vers `/chat`, et ajout d’un test `node --import tsx --test tests/unit/auth-sign-in-response.test.ts` confirmant le scénario.
-- **2025-11-22** — Déplacement de `router.replace` avant la fenêtre d’attente toast pour lancer immédiatement la navigation `/chat` après inscription, exécution ciblée de `register-page.spec.tsx` (avec dépendance coverage optionnelle refusée) et mise à jour du plan de remédiation.
-- **2025-11-23** — Ajout d’un warning explicite quand `Messages` perd des artefacts finance après parsing et extension de la suite RTL pour vérifier qu’un backtest persiste après un rendu séquentiel (chart → backtest).
-- **2025-11-24** — Normalisation des cookies d’auth Playwright (construction d’URL + chemin) et journalisation des métadonnées applicables pour identifier les erreurs `context.addCookies` lors du warm-up.
-- **2025-11-25** — Ajustement de l’injection des cookies Playwright pour n’utiliser que l’origine (sans slash final) et retirer la propriété `path` avant `context.addCookies`, mise à jour des helpers (`tests/setup/auth.setup.ts`, `tests/helpers.ts`), et exécution ciblée de `pnpm exec vitest run tests/unit/helpers/create-auth-context.spec.ts --reporter=basic`, `pnpm exec vitest run tests/unit/utils/programmatic-login.spec.ts --reporter=basic`, `pnpm exec vitest run tests/unit/utils/load-credentials.spec.ts --reporter=basic`.
-- **2025-11-26** — Journalisation de l’ultime état observé dans `pollForStreamingChange` avant timeout (injection dans `logStreamingProbe` + message d’erreur détaillé), tentative de relance `PLAYWRIGHT=true pnpm exec playwright test tests/e2e/accessibility.spec.ts` interrompue faute de dev-server stable, et essai `pnpm dlx vitest@2.1.9 run tests/unit/components/messages.spec.tsx --reporter=basic` bloqué par la dépendance optionnelle `jsdom` manquante.
-- **2025-11-28** — Ajout d’un snapshot `console.debug` conditionné par `DEBUG=playwright` dans `convertToUIMessages`, mise à jour du test RTL séquentiel pour passer par `convertToUIMessages`, écriture d’un test Vitest ciblant le logging Playwright et exécution de `pnpm exec vitest run tests/unit/components/messages.spec.tsx --reporter=basic`, `pnpm exec vitest run tests/unit/ai/messages.spec.ts --reporter=basic`.
-- **2025-11-29** — Appel immédiat de `ensureHardRedirect()` après `router.replace` dans la page register pour éviter les blocages de redirection Playwright, et mise à jour du test RTL `register-page.spec.tsx` pour s’assurer que le premier appel `window.location.assign` vise bien le tableau de bord.
-- **2025-11-30** — Coercition des périodes `finance.backtest` (schéma Zod, API et mocks) vers des chaînes ISO pour empêcher l’éjection des artefacts, ajout d’un test Vitest couvrant les epochs numériques et exécution ciblée de `vitest run tests/unit/ai/messages.spec.ts` et `tests/unit/routes/finance.backtest.spec.ts`.
-- **2025-12-01** — Ajout d’un test ciblé `ChatPage.isGenerationComplete` couvrant le signal du placeholder de chargement, avec stubs JSDOM pour valider la progression ; tentative Playwright `tests/e2e/accessibility.spec.ts --reporter=dot` soldée par un timeout `beforeEach` (contexte fermé avant `send-button`), trace conservée pour analyse ultérieure.
-- **2025-12-02** — Extension des signaux de progression Playwright (`ChatPage.isGenerationComplete`) pour considérer le compteur `__PLAYWRIGHT_CHAT_SIGNALS__`, la visibilité des boutons send/stop, la valeur du composer et les suggestions rapides. Ajout de deux tests Vitest ciblés (`assistant loading placeholder`, `chat signal increments`) exécutés isolément, tentative de lancer la suite complète `tests/unit/pages/chat-page.spec.ts` avortée pour cause d’OOM (`ERR_WORKER_OUT_OF_MEMORY`), et relance `DEBUG=playwright pnpm exec playwright test tests/e2e/accessibility.spec.ts --reporter=dot` toujours en échec (artefact backtest absent). Notes et traces consignées dans la checklist ci-dessus.
-- **2025-12-03** — Réparation du helper `pollForStreamingChange` en restaurant les accolades manquantes autour du comptage d'artefacts (erreur `Unexpected token` lors des runs Playwright/Vitest), puis vérification via `pnpm exec vitest run tests/unit/pages/chat-page.spec.ts --reporter=basic -t "chat signal increments"`.
-- **2025-12-04** — Réinstallation complète des dépendances (`pnpm install`), téléchargement des navigateurs/dépendances système Playwright, puis exécution ciblée de `pnpm exec playwright test tests/e2e/session.test.ts --project=e2e --grep "Register new account"`. La session est créée mais la page reste sur `/register` (timeout `waitForChatDashboard`) ; trace archivée pour analyse ultérieure.
+# Agent Brief — reset 2025-12-09
+
+## Context
+The latest `pnpm e2e` run (2025-12-09) exposed two blocking regressions in addition to the previously failing edit flows:
+- **Chat activity › Send a user message and receive response** — No assistant messages ever appear (`data-testid="message-assistant"` count remains 0), so even the first chat send stalls.
+- **chat activity with reasoning › Curie can edit message and resubmit** — The polling assertion still captures the pre-edit assistant reply instead of the refreshed answer.
+
+Accessibility, finance, registration, and other chat scenarios now pass, so the remaining scope is focused on restoring assistant message rendering and edit resiliency.
+
+## Objectives
+- Restore deterministic streaming behaviour after editing chat messages for both standard and reasoning conversations.
+- Ensure the reasoning transcript helpers observe the refreshed assistant output after an edit.
+- Guarantee that a newly registered account lands on an interactive chat (composer visible, chat id present).
+- Keep the Playwright auth warm-up and storage state reuse intact while iterating on the fixes above.
+
+## Task Checklist
+
+### 1. Assistant message regression (baseline send fails)
+- [ ] Reproduce the missing assistant bubble locally (focus the "Send a user message and receive response" test) and inspect the DOM to confirm whether the assistant block fails to mount or is immediately removed. *(still blocked — browsers installed but `playwright install-deps` pulls ~500 MB of packages; run once the environment budget allows)*
+- [x] Trace the message rendering pipeline (`components/messages.tsx`, `lib/chat/message-status.ts`, `lib/ai/providers.ts`) to ensure assistant messages remain in the array after edits and that status derivation does not filter them out.
+- [x] Add unit coverage (ideally in `tests/unit/components/message*.spec.tsx`) that asserts assistant messages render when the provider returns a response without a `status` field.
+- [x] Patch the chat surface (`components/chat.tsx`) to synthesise stable identifiers as soon as streamed assistant messages land and emit diagnostics for every fallback.
+- [x] Guard synthetic identifier generation when `metadata.createdAt` is missing so the renderer never throws while streaming transient payloads.
+- [x] Refine identifier normalisation to mutate the existing message collection unless objects are non-extensible, and add unit coverage for the cloned-array fallback.
+- [x] Guard the identifier normalisation effect against stale snapshots by funnelling updates through `setMessages` functional setters.
+- [ ] Run `pnpm exec playwright test tests/e2e/chat.test.ts -g "Send a user message and receive response"` and keep the passing trace for reference. *(2025-12-12 — intermittent: first rerun under `PLAYWRIGHT_STREAM_DEBUG=1` passed once, subsequent attempt regressed with zero assistant messages; latest local attempt fails earlier because Playwright browsers are missing — install via `pnpm exec playwright install` before the next rerun.)*
+
+### 2. Chat edit/resubmit streaming
+- [ ] Verify that whatever fix restores baseline assistant rendering also re-enables the edit flow; if not, instrument `ChatPage.waitForUiStreamingFallback` to log the message ids and statuses it observes.
+- [ ] Ensure the updated message state triggers a `streaming → complete` transition on edits, updating both helper logic and component props as needed.
+- [ ] Extend the existing Vitest coverage to include an edit scenario where the assistant response arrives without explicit status flags.
+- [ ] Re-run `pnpm exec playwright test tests/e2e/chat.test.ts -g "Edit user message and resubmit"` and archive the trace on success.
+
+### 3. Reasoning edit/resubmit expectations
+- [ ] Confirm how `ChatPage.getRecentAssistantMessage` filters reasoning turns and adjust it to fetch the latest assistant content after edits.
+- [x] Align the reasoning mock provider (if applicable) so that re-issued prompts return updated reasoning steps plus the final answer.
+- [ ] Extend `tests/e2e/reasoning.test.ts` with stronger polling (or helper assertions) that validate the message actually changes.
+- [ ] Re-run `pnpm exec playwright test tests/e2e/reasoning.test.ts -g "Curie can edit message and resubmit"` to validate.
+
+### 4. Registration composer visibility
+- [x] Instrument the registration action/page to log the redirect target and the created chat id when running under `PLAYWRIGHT=true`.
+- [x] Ensure the server-side registration flow creates or fetches a chat and returns a redirect to `/chat/:id`.
+- [ ] Update the client-side onboarding hook so the composer mounts even if the session refresh is still in flight.
+- [x] Add coverage (unit or integration) proving a freshly registered user sees an enabled composer.
+- [ ] Re-run `pnpm exec playwright test tests/e2e/session.test.ts -g "Register new account"` and inspect the trace for the composer state.
+
+## Validation Matrix
+Run the following once all fixes are applied:
+1. `pnpm exec vitest run tests/unit/ai/providers.spec.ts tests/unit/pages/chat-page.spec.ts`
+2. `pnpm exec playwright test tests/e2e/chat.test.ts -g "Edit user message and resubmit"`
+3. `pnpm exec playwright test tests/e2e/reasoning.test.ts -g "Curie can edit message and resubmit"`
+4. `pnpm exec playwright test tests/e2e/session.test.ts -g "Register new account"`
+5. `pnpm e2e`
+
+## Handoff Notes
+- Keep `DEBUG=playwright` handy for additional instrumentation; traces from the failing runs live under `playwright-results/` with matching names.
+- Avoid modifying the Playwright storage state schema unless necessary; current runs regenerate credentials when missing.
+- Document any new instrumentation directly in the relevant module comments so future agents can disable it cleanly.
+- 2025-12-08 — Introduced `lib/ai/prompt-helpers.ts` so both the inline mocks and the production provider select the freshest user/tool prompt, and updated `tests/prompts/utils.spec.ts`/`tests/unit/ai/providers.spec.ts` accordingly. Registration flow now logs seeded chat ids under Playwright and prefers the seeded redirect over the generic `/chat` fallback; added unit coverage for both success branches. Targeted Vitest suites pass (`ai/providers`, prompts, auth actions) but `tests/unit/pages/chat-page.spec.ts` repeatedly exhausted the container (SIGKILL) and the focused Playwright edit test still stalls with zero assistant messages; traces saved under `playwright-results/e2e-chat-Chat-activity-Edit-user-message-and-resubmit-e2e/` for investigation.
+- 2025-12-09 — Added `lib/chat/message-status.ts` to derive deterministic assistant statuses and rewired `components/messages.tsx` to consume it so inline edits always surface a `streaming` flag. Introduced `tests/unit/components/messages.status.spec.ts` to cover the fallback logic. Targeted edit Playwright run still times out because no assistant bubble ever reattaches (`message-assistant` count stays at 0); inspect the latest trace under `playwright-results/e2e-chat-Chat-activity-Edit-user-message-and-resubmit-e2e/` for DOM + network clues.
+- 2025-12-10 — Latest full `pnpm e2e` run shows baseline chat send now fails (no assistant messages rendered) while the reasoning edit resubmit still returns the pre-edit answer. Accessibility and registration flows pass. Focus next steps on restoring assistant message rendering and updating reasoning polling once baseline chat behaviour is recovered. Relevant traces: `playwright-results/e2e-chat-Chat-activity-Sen-83c51-essage-and-receive-response-e2e/` and `playwright-results/e2e-reasoning-chat-activit-c5759-n-edit-message-and-resubmit-e2e/`.
+- 2025-12-11 — Normalised message hydration in `components/messages.tsx` to tolerate missing `parts` arrays and emit targeted diagnostics, added `tests/unit/components/messages.render.spec.tsx` to lock in the regression fix, and started the Playwright browser/dependency installs so targeted chat runs can execute locally (still downloading system packages — rerun the focused chat test once the install completes).
+- 2025-12-11 — Synthesised fallback message identifiers in `components/messages.tsx` so assistant bubbles render even when the SDK omits `id`, added unit coverage for the synthetic-id path, and attempted to run the focused chat Playwright test. Browsers are now installed but the shared container lacks the desktop dependencies (`playwright install-deps` tries to fetch ~500 MB); rerun the e2e check once the host allows the package install.
+- 2025-12-11 — Added `lib/chat/message-identifiers.ts` with helpers shared by `components/chat.tsx` and `components/messages.tsx` so streamed assistant replies receive deterministic ids before rendering. Patched the chat component to log each synthesised identifier and wrote `tests/unit/lib/chat.message-identifiers.spec.ts` to lock the behaviour before rerunning targeted renderer tests. Playwright checks remain blocked until the container installs the browser dependencies.
+- 2025-12-12 — Hardened the identifier helper against absent metadata timestamps, added regression coverage, and reran the focused chat Playwright test (still failing with zero assistant messages despite the guard; see latest trace under `playwright-results/e2e-chat-Chat-activity-Sen-83c51-essage-and-receive-response-e2e/`).
+- 2025-12-12 — Instrumented the chat surface and mock provider with stream-aware diagnostics, then reran `pnpm exec playwright test tests/e2e/chat.test.ts -g "Send a user message and receive response"` under `PLAYWRIGHT_STREAM_DEBUG=1`. The first rerun passed but the follow-up attempt still timed out with zero assistant bubbles; keep the new debug hooks while triaging the remaining regressions.
+- 2025-12-12 — Updated `lib/chat/message-identifiers.ts` to retain the existing message array when possible (only cloning when messages are frozen), adjusted `components/chat.tsx` to reuse that signal, and expanded the identifier unit suite accordingly. Focused `pnpm exec playwright test … "Send a user message and receive response"` still times out in the `beforeEach` navigation after ~4 minutes, so baseline assistant rendering remains unresolved.
+- 2025-12-12 — Channelled the identifier normalisation effect through the functional `setMessages` updater to avoid overriding newer chat payloads, introduced `prepareNormalisedMessageUpdate` for reuse, and extended the identifier tests to cover the new helper. Targeted Playwright chat run is still pending because the shared container lacks installed browsers (`pnpm exec playwright install` required).

--- a/app/(auth)/actions.ts
+++ b/app/(auth)/actions.ts
@@ -1,10 +1,13 @@
 "use server";
 
+import { createHash } from "node:crypto";
+
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
 
 import { didSignInSucceed, extractRedirectPath } from "@/lib/auth/sign-in-response";
 import { createInitialChat, createUser, getUser } from "@/lib/db/queries";
+import { logWarning } from "@/lib/logging";
 
 import { signIn } from "./auth";
 
@@ -114,29 +117,39 @@ export const register = async (
     await createUser(validatedData.email, validatedData.password);
 
     /**
-     * Fetch the freshly inserted account so we can seed an onboarding chat tied
-     * to the real user identifier. When the lookup fails we fall back to the
-     * generic failure state, signalling the client to display the error toast
-     * instead of attempting a redirect with an unknown chat id.
+     * Seed an onboarding chat for the freshly created account so newcomers land
+     * on a populated workspace. If we fail to retrieve the account metadata we
+     * still proceed with the credentials hand-off and fall back to the generic
+     * dashboard redirect to avoid trapping the user on the register screen.
      */
     const [createdUser] = await getUser(validatedData.email);
 
-    if (!createdUser) {
-      return { status: "failed" } as RegisterActionState;
+    let seededChatRedirect: string | undefined;
+
+    if (createdUser) {
+      const initialChat = await createInitialChat({
+        userId: createdUser.id,
+      });
+
+      /**
+       * Ensure the chat dashboard and the newly provisioned conversation render
+       * up-to-date data the moment the client redirects by invalidating their
+       * cached pages. This mirrors the behaviour of the regular chat creation
+       * flow triggered from the sidebar.
+       */
+      revalidatePath("/chat");
+      revalidatePath(`/chat/${initialChat.chatId}`);
+
+      seededChatRedirect = `/chat/${initialChat.chatId}`;
+    } else {
+      logWarning(
+        "auth:register",
+        "Registration succeeded but the new user record was not immediately available; falling back to the dashboard redirect",
+        {
+          emailFingerprint: anonymiseEmail(validatedData.email),
+        }
+      );
     }
-
-    const initialChat = await createInitialChat({
-      userId: createdUser.id,
-    });
-
-    /**
-     * Ensure the chat dashboard and the newly provisioned conversation render
-     * up-to-date data the moment the client redirects by invalidating their
-     * cached pages. This mirrors the behaviour of the regular chat creation
-     * flow triggered from the sidebar.
-     */
-    revalidatePath("/chat");
-    revalidatePath(`/chat/${initialChat.chatId}`);
 
     const signInResponse = await signIn("credentials", {
       email: validatedData.email,
@@ -161,9 +174,10 @@ export const register = async (
       return { status: "failed" };
     }
 
-    const redirectTo = extractRedirectPath(signInResponse, {
-      baseUrl: process.env.NEXTAUTH_URL ?? "http://localhost:3000",
-    }) ?? `/chat/${initialChat.chatId}`;
+    const redirectTo =
+      extractRedirectPath(signInResponse, {
+        baseUrl: process.env.NEXTAUTH_URL ?? "http://localhost:3000",
+      }) ?? seededChatRedirect ?? "/chat";
 
     return {
       status: "success",
@@ -177,3 +191,18 @@ export const register = async (
     return { status: "failed" };
   }
 };
+
+/**
+ * Generate a deterministic fingerprint for an email address before logging it
+ * so we can correlate diagnostics without exposing personally identifiable
+ * information in shared CI logs.
+ */
+function anonymiseEmail(email: string): string {
+  if (email.length === 0) {
+    return "[redacted]";
+  }
+
+  const digest = createHash("sha256").update(email).digest("hex");
+
+  return `[fingerprint:${digest.slice(0, 12)}]`;
+}

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -383,7 +383,7 @@ export function Chat({
      * `null` sans heurter le typage strict de TypeScript (5.6+ interdirait
      * l'accès à `.length` sur un union non raffiné dans une expression `||`).
      */
-    if (!patchesToLog) {
+    if (!Array.isArray(patchesToLog)) {
       /**
        * Aucun correctif à journaliser lorsque le normaliseur n'a généré aucun
        * patch (ou que la fonction de préparation a court-circuité). Nous
@@ -393,7 +393,9 @@ export function Chat({
       return;
     }
 
-    if (patchesToLog.length === 0) {
+    const patches = patchesToLog as IdentifierPatch[];
+
+    if (patches.length === 0) {
       /**
        * Même lorsqu'un tableau est renvoyé, il peut être vide. Nous évitons un
        * for-of inutile et laissons la boucle principale se déclencher uniquement
@@ -402,7 +404,7 @@ export function Chat({
       return;
     }
 
-    for (const patch of patchesToLog) {
+    for (const patch of patches) {
       logWarning(
         "chat:messages",
         "[Chat] synthesised fallback identifier for streamed message",

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -17,6 +17,7 @@ import type { Attachment, ChatMessage, MessageMetadata } from "@/lib/types";
 import { messageMetadataSchema } from "@/lib/types";
 import type { AppUsage } from "@/lib/usage";
 import { logPlaywrightStreamDebug } from "@/lib/playwright-debug";
+import { logWarning } from "@/lib/logging";
 import { fetcher, fetchWithErrorHandlers, generateUUID } from "@/lib/utils";
 import {
   ChatComposerPrefillOptions,
@@ -26,6 +27,10 @@ import { Artifact } from "./artifact";
 import { useOptionalDataStream } from "./data-stream-provider";
 import { Messages } from "./messages";
 import { MultimodalInput } from "./multimodal-input";
+import {
+  prepareNormalisedMessageUpdate,
+  type IdentifierPatch,
+} from "@/lib/chat/message-identifiers";
 import { getChatHistoryPaginationKey } from "./sidebar-history";
 import { toast } from "./toast";
 import type { VisibilityType } from "./visibility-selector";
@@ -285,6 +290,97 @@ export function Chat({
 
     return messages;
   }, [messages]);
+
+  useEffect(() => {
+    /**
+     * Surface the roles and lifecycle states observed by the chat hook when
+     * Playwright stream debug mode is active.  This keeps the noisy logging
+     * hidden during regular sessions while giving end-to-end diagnostics an
+     * easy way to confirm that assistant messages are still present in the
+     * state array when the DOM disagrees.
+     */
+    logPlaywrightStreamDebug("chat-component", "messages-summary", () => ({
+      count: safeMessages.length,
+      messages: safeMessages.map((message, index) => {
+        const partTypes = Array.isArray(message?.parts)
+          ? message!.parts.map((part) =>
+              part && typeof part === "object" && "type" in part
+                ? (part as { type?: unknown }).type ?? typeof part
+                : typeof part
+            )
+          : null;
+
+        const textPreview = Array.isArray(message?.parts)
+          ? message!.parts
+              .filter(
+                (part): part is { type: string; text?: string } =>
+                  Boolean(part) &&
+                  typeof part === "object" &&
+                  "type" in part &&
+                  (part as { type?: unknown }).type === "text"
+              )
+              .map((part) => (part.text ?? "").slice(0, 80))
+          : null;
+
+        return {
+          index,
+          id:
+            typeof message?.id === "string" && message.id.trim().length > 0
+              ? message.id
+              : null,
+          role: message?.role ?? "unknown",
+          status: message?.status ?? null,
+          partTypes,
+          textPreview,
+        };
+      }),
+    }));
+  }, [safeMessages]);
+
+  /**
+   * Les flux d'assistant observés via Playwright exposent parfois des messages
+   * dépourvus d'identifiant stable. Nous normalisons ici la collection dès que
+   * le hook `useChat` la met à jour afin de conserver un état cohérent pour les
+   * actions (votes, édition) et pour les outils de synchronisation e2e.
+   */
+  useEffect(() => {
+    if (!Array.isArray(messages) || messages.length === 0) {
+      return;
+    }
+
+    let patchesToLog: IdentifierPatch[] | null = null;
+
+    setMessages((currentMessages) => {
+      const prepared = prepareNormalisedMessageUpdate({
+        chatId: id,
+        messages: currentMessages,
+      });
+
+      if (!prepared) {
+        return currentMessages;
+      }
+
+      patchesToLog = prepared.patches;
+      return prepared.messages;
+    });
+
+    if (!Array.isArray(patchesToLog) || patchesToLog.length === 0) {
+      return;
+    }
+
+    for (const patch of patchesToLog) {
+      logWarning(
+        "chat:messages",
+        "[Chat] synthesised fallback identifier for streamed message",
+        {
+          chatId: id,
+          fallbackMessageId: patch.fallbackId,
+          index: patch.index,
+          role: patch.role,
+        }
+      );
+    }
+  }, [id, messages, setMessages]);
 
   const { data: votes } = useSWR<Vote[]>(
     safeMessages.length >= 2 ? `/api/vote?chatId=${id}` : null,

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -377,7 +377,13 @@ export function Chat({
       return prepared.messages;
     });
 
-    if (!Array.isArray(patchesToLog) || patchesToLog.length === 0) {
+    /**
+     * Lorsque le normalisateur n'applique aucun correctif nous sortons tôt :
+     * l'opérateur optionnel permet de couvrir le cas où `patchesToLog` reste
+     * `null` sans heurter le typage strict de TypeScript (5.6+ interdirait
+     * l'accès à `.length` sur un union non raffiné dans une expression `||`).
+     */
+    if (!patchesToLog || patchesToLog.length === 0) {
       return;
     }
 

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -310,15 +310,28 @@ export function Chat({
             )
           : null;
 
+        /**
+         * Conserver une référence typée vers les parties "text" du SDK nous
+         * permet de bénéficier du raffinement TypeScript tout en conservant la
+         * souplesse du filtre runtime utilisé pour les diagnostics Playwright.
+         */
+        type TextPart = Extract<
+          NonNullable<ChatMessage["parts"]>[number],
+          { type: "text"; text?: string }
+        >;
+
         const textPreview = Array.isArray(message?.parts)
           ? message!.parts
-              .filter(
-                (part): part is { type: string; text?: string } =>
-                  Boolean(part) &&
-                  typeof part === "object" &&
+              .filter((part): part is TextPart => {
+                if (!part || typeof part !== "object") {
+                  return false;
+                }
+
+                return (
                   "type" in part &&
                   (part as { type?: unknown }).type === "text"
-              )
+                );
+              })
               .map((part) => (part.text ?? "").slice(0, 80))
           : null;
 

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -101,7 +101,16 @@ export function Chat({
     resumeStream,
   } = useChat<ChatMessage>({
     id,
-    messages: initialMessages,
+    /**
+     * `useChat` exposes both a controlled `messages` prop and an
+     * `initialMessages` seed.  We deliberately rely on the uncontrolled
+     * variant so the hook can append streaming payloads to its internal state
+     * without React treating our prop as the single source of truth.  Passing
+     * the controlled prop here would freeze the conversation to the initial
+     * snapshot (an empty array during first render) which is exactly what the
+     * Playwright suite observed when no assistant bubble ever appeared.
+     */
+    initialMessages,
     experimental_throttle: 100,
     generateId: generateUUID,
     transport: new DefaultChatTransport({
@@ -361,6 +370,26 @@ export function Chat({
       return;
     }
 
+    /**
+     * Éviter de déclencher systématiquement le setter lorsque tous les messages
+     * disposent déjà d'un identifiant stable. Cela limite les écritures
+     * concurrentes pendant le streaming tout en conservant le normaliseur pour
+     * les rares flux où le SDK omet l'`id`.
+     */
+    const hasMessageWithoutId = messages.some((message) => {
+      if (!message || typeof message !== "object") {
+        return false;
+      }
+
+      return !(
+        typeof message.id === "string" && message.id.trim().length > 0
+      );
+    });
+
+    if (!hasMessageWithoutId) {
+      return;
+    }
+
     let patchesToLog: IdentifierPatch[] | null = null;
 
     setMessages((currentMessages) => {
@@ -377,34 +406,11 @@ export function Chat({
       return prepared.messages;
     });
 
-    /**
-     * Lorsque le normalisateur n'applique aucun correctif nous sortons tôt :
-     * l'opérateur optionnel permet de couvrir le cas où `patchesToLog` reste
-     * `null` sans heurter le typage strict de TypeScript (5.6+ interdirait
-     * l'accès à `.length` sur un union non raffiné dans une expression `||`).
-     */
-    if (!Array.isArray(patchesToLog)) {
-      /**
-       * Aucun correctif à journaliser lorsque le normaliseur n'a généré aucun
-       * patch (ou que la fonction de préparation a court-circuité). Nous
-       * sortons tôt pour éviter d'accéder à `.length` tant que TypeScript n'a
-       * pas raffiné l'union vers `IdentifierPatch[]`.
-       */
+    if (!Array.isArray(patchesToLog) || patchesToLog.length === 0) {
       return;
     }
 
-    const patches = patchesToLog as IdentifierPatch[];
-
-    if (patches.length === 0) {
-      /**
-       * Même lorsqu'un tableau est renvoyé, il peut être vide. Nous évitons un
-       * for-of inutile et laissons la boucle principale se déclencher uniquement
-       * lorsque des identifiants synthétiques ont réellement été créés.
-       */
-      return;
-    }
-
-    for (const patch of patches) {
+    for (const patch of patchesToLog) {
       logWarning(
         "chat:messages",
         "[Chat] synthesised fallback identifier for streamed message",

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -383,7 +383,22 @@ export function Chat({
      * `null` sans heurter le typage strict de TypeScript (5.6+ interdirait
      * l'accès à `.length` sur un union non raffiné dans une expression `||`).
      */
-    if (!patchesToLog || patchesToLog.length === 0) {
+    if (!patchesToLog) {
+      /**
+       * Aucun correctif à journaliser lorsque le normaliseur n'a généré aucun
+       * patch (ou que la fonction de préparation a court-circuité). Nous
+       * sortons tôt pour éviter d'accéder à `.length` tant que TypeScript n'a
+       * pas raffiné l'union vers `IdentifierPatch[]`.
+       */
+      return;
+    }
+
+    if (patchesToLog.length === 0) {
+      /**
+       * Même lorsqu'un tableau est renvoyé, il peut être vide. Nous évitons un
+       * for-of inutile et laissons la boucle principale se déclencher uniquement
+       * lorsque des identifiants synthétiques ont réellement été créés.
+       */
       return;
     }
 

--- a/components/messages.tsx
+++ b/components/messages.tsx
@@ -18,6 +18,10 @@ import { financeMessageArtifactSchema } from "@/lib/artifacts/types";
 import * as featureFlags from "@/lib/feature-flags";
 import { logWarning } from "@/lib/logging";
 import { logPlaywrightStreamDebug } from "@/lib/playwright-debug";
+import {
+  resolveStableMessageId,
+} from "@/lib/chat/message-identifiers";
+import { deriveAssistantMessageStatus } from "@/lib/chat/message-status";
 
 type MessagesProps = {
   chatId: string;
@@ -32,12 +36,10 @@ type MessagesProps = {
   financeFeatureEnabledOverride?: boolean;
 };
 
-const isRenderableMessage = (value: ChatMessage | null | undefined): value is ChatMessage => {
-  return (
-    Boolean(value) &&
-    typeof value?.id === "string" &&
-    Array.isArray(value.parts)
-  );
+const isRenderableMessage = (
+  value: ChatMessage | null | undefined
+): value is ChatMessage => {
+  return Boolean(value) && typeof value?.role === "string";
 };
 
 type InvalidArtifactLog = {
@@ -158,6 +160,20 @@ function PureMessages({
   const safeVotes = Array.isArray(votes) ? votes : votes ?? [];
 
   /**
+   * Locate the last assistant reply so we can surface a deterministic
+   * lifecycle attribute for inline regenerations that reuse the same DOM
+   * container.
+   */
+  const latestAssistantIndex = (() => {
+    for (let index = safeMessages.length - 1; index >= 0; index -= 1) {
+      if (safeMessages[index]?.role === "assistant") {
+        return index;
+      }
+    }
+    return -1;
+  })();
+
+  /**
    * Evaluate the finance flag once per render. Tests can inject
    * `financeFeatureEnabledOverride` to force the disabled branch without
    * mutating global process state.
@@ -234,9 +250,57 @@ function PureMessages({
               );
             }
 
+            const { id: stableMessageId, isSynthetic } = resolveStableMessageId({
+              chatId,
+              index,
+              message,
+            });
+
             const matchingVote = safeVotes.find(
-              (vote) => vote.messageId === message.id
+              (vote) => vote.messageId === stableMessageId
             );
+
+            if (isSynthetic) {
+              logWarning(
+                "chat:messages",
+                "[Messages] message arrived without a stable id; synthesising fallback",
+                {
+                  chatId,
+                  fallbackMessageId: stableMessageId,
+                  role: message.role,
+                }
+              );
+            }
+
+            /**
+             * Guard against upstream payloads that temporarily omit the `parts`
+             * array.  The Vercel AI SDK promises to attach the collection, yet
+             * we have observed transient states where Playwright snapshots only
+             * expose the other message fields.  Normalising the shape here keeps
+             * the renderer stable and emits a diagnostic so future agents can
+             * investigate the upstream race without sacrificing end-user
+             * resilience.
+             */
+            const messageWithUnknownParts = message as unknown as {
+              parts?: ChatMessage["parts"] | unknown;
+            };
+            const hasRenderableParts = Array.isArray(
+              messageWithUnknownParts.parts
+            );
+            const originalParts = hasRenderableParts
+              ? (messageWithUnknownParts.parts as ChatMessage["parts"])
+              : [];
+
+            if (!hasRenderableParts) {
+              logWarning(
+                "chat:messages",
+                "[Messages] message arrived without a parts array; defaulting to empty",
+                {
+                  messageId: stableMessageId,
+                  role: message.role,
+                }
+              );
+            }
 
             /**
              * Guard the artefact list because assistant responses sometimes
@@ -296,8 +360,8 @@ function PureMessages({
               return typeof transientValue === "boolean" ? transientValue : false;
             };
 
-            const deduplicatedParts = Array.isArray(message.parts)
-              ? message.parts.reduce<ChatMessage["parts"]>((acc, part) => {
+            const deduplicatedParts = originalParts.length > 0
+              ? originalParts.reduce<ChatMessage["parts"]>((acc, part) => {
                   if (
                     !part ||
                     typeof part !== "object" ||
@@ -391,7 +455,7 @@ function PureMessages({
                   const parsed = parseFinanceArtifact(
                     candidate.value,
                     artifactIndex,
-                    message.id,
+                    stableMessageId,
                     invalidArtifacts,
                     candidate.typeHint
                   );
@@ -422,7 +486,7 @@ function PureMessages({
                 "[Messages] finance artefact candidates dropped after parsing",
                 {
                   artifactCandidateCount: artifactCandidates.length,
-                  messageId: message.id,
+                  messageId: stableMessageId,
                 }
               );
             }
@@ -436,20 +500,37 @@ function PureMessages({
                */
               logWarning("chat:messages", "[Messages] finance artefact hidden by feature flag", {
                 artifactCount: artifactCandidates.length,
-                messageId: message.id,
+                messageId: stableMessageId,
               });
             }
 
             const normalisedMessage = {
               ...message,
               artifacts: sanitizedArtifacts,
+              id: stableMessageId,
               parts: deduplicatedParts,
             } as ChatMessage;
+
+            const derivedStatus = deriveAssistantMessageStatus({
+              index,
+              latestAssistantIndex,
+              chatStatus: status,
+              messageStatus: normalisedMessage.status,
+              role: normalisedMessage.role,
+            });
+
+            const messageForRender =
+              derivedStatus && derivedStatus !== normalisedMessage.status
+                ? ({
+                    ...normalisedMessage,
+                    status: derivedStatus,
+                  } as ChatMessage)
+                : normalisedMessage;
 
             const invalidCount = financeFeatureEnabled ? invalidArtifacts.length : 0;
 
             logPlaywrightStreamDebug("messages", "message-normalised", () => ({
-              messageId: message.id,
+              messageId: stableMessageId,
               artifactCandidateCount: artifactCandidates.length,
               sanitizedArtifactCount: sanitizedArtifacts.length,
               financeFingerprintCount: financePartFingerprints.size,
@@ -459,14 +540,14 @@ function PureMessages({
             }));
 
             return (
-              <Fragment key={message.id}>
+              <Fragment key={stableMessageId}>
                 <PreviewMessage
                   chatId={chatId}
                   isLoading={
                     status === "streaming" && safeMessages.length - 1 === index
                   }
                   isReadonly={isReadonly}
-                  message={normalisedMessage}
+                  message={messageForRender}
                   regenerate={regenerate}
                   requiresScrollPadding={
                     hasSentMessage && index === safeMessages.length - 1

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -18,6 +18,7 @@ import type { ModelMessage } from "ai";
 import { isPlaywrightLikeEnvironment } from "./playwright-env";
 import { DEFAULT_ONBOARDING_SUGGESTION } from "../constants";
 import { logWarning } from "@/lib/logging";
+import { logPlaywrightStreamDebug } from "@/lib/playwright-debug";
 
 type CreateOpenAI = typeof import("@ai-sdk/openai").createOpenAI;
 
@@ -339,11 +340,105 @@ function buildPlaywrightChunks({
   readonly includeReasoning: boolean;
   readonly fallbackText: string;
 }): LanguageModelV2StreamPart[] {
+  /**
+   * When stream debugging is enabled we surface the mock provider prompt so
+   * Playwright traces can confirm which roles and fragments were evaluated. The
+   * payload is truncated to keep console output manageable while still showing
+   * the most recent text edits.
+   */
+  logPlaywrightStreamDebug(
+    "mock-provider",
+    "build-playwright-chunks",
+    () => ({
+      promptRoles: prompt.map((message) => message?.role ?? "unknown"),
+      promptContent: prompt.map((message, index) => ({
+        index,
+        role: message?.role ?? "unknown",
+        contentSummary: Array.isArray(message?.content)
+          ? message.content
+              .map((fragment) => {
+                if (fragment == null) {
+                  return null;
+                }
+
+                if (typeof fragment === "string") {
+                  return fragment.slice(0, 80);
+                }
+
+                if (
+                  typeof fragment === "object" &&
+                  "text" in fragment &&
+                  typeof (fragment as { text?: unknown }).text === "string"
+                ) {
+                  return (fragment as { text: string }).text.slice(0, 80);
+                }
+
+                if (
+                  typeof fragment === "object" &&
+                  "input_text" in fragment &&
+                  typeof (fragment as { input_text?: unknown }).input_text === "string"
+                ) {
+                  return (fragment as { input_text: string }).input_text.slice(0, 80);
+                }
+
+                return fragment;
+              })
+              .filter((value) => value != null)
+          : message?.content ?? null,
+      })),
+    }),
+    { withTimestamp: true }
+  );
+
   const recentMessage = resolveLatestRelevantMessage(prompt);
 
   if (!recentMessage) {
     throw new Error("No recent user message found!");
   }
+
+  /**
+   * Emit the resolved message as well so we can detect mismatches between the
+   * prompt sequence and the candidate the provider ultimately selects.
+   */
+  logPlaywrightStreamDebug(
+    "mock-provider",
+    "recent-message",
+    () => ({
+      role: recentMessage.role,
+      contentSummary: Array.isArray(recentMessage.content)
+        ? recentMessage.content
+            .map((fragment) => {
+              if (fragment == null) {
+                return null;
+              }
+
+              if (typeof fragment === "string") {
+                return fragment.slice(0, 80);
+              }
+
+              if (
+                typeof fragment === "object" &&
+                "text" in fragment &&
+                typeof (fragment as { text?: unknown }).text === "string"
+              ) {
+                return (fragment as { text: string }).text.slice(0, 80);
+              }
+
+              if (
+                typeof fragment === "object" &&
+                "input_text" in fragment &&
+                typeof (fragment as { input_text?: unknown }).input_text === "string"
+              ) {
+                return (fragment as { input_text: string }).input_text.slice(0, 80);
+              }
+
+              return fragment;
+            })
+            .filter((value) => value != null)
+        : recentMessage.content ?? null,
+    }),
+    { withTimestamp: true }
+  );
 
   if (includeReasoning) {
     const reasoningChunks = resolveReasoningPrompt(recentMessage);
@@ -367,28 +462,32 @@ function resolveLatestRelevantMessage(
   prompt: ModelMessage[]
 ): ModelMessage | null {
   /**
-   * Tool responses arrive immediately before the assistant synthesises the
-   * final answer. Prioritise those payloads so the inline mocks can emit
-   * follow-up text without re-triggering the tool dispatch. When no tool
-   * result is present we fall back to the latest user-authored message so edit
-   * flows honour the freshly submitted prompt. The terminal entry remains the
-   * final fallback to keep the fixtures permissive for any future payload
-   * shapes.
+   * Tool responses generally precede the assistant’s final reply, but edit
+   * flows append a fresh user message after the tool output. We track the last
+   * observed indices for user and tool roles so we can prefer the edited
+   * prompt when it truly appears after a tool run, while still keeping the tool
+   * payload handy when no override exists. The terminal entry remains a
+   * fallback to keep the mocks tolerant of future payload permutations.
    */
-  for (let index = prompt.length - 1; index >= 0; index -= 1) {
+  let lastUserIndex = -1;
+  let lastToolIndex = -1;
+
+  for (let index = 0; index < prompt.length; index += 1) {
     const candidate = prompt[index];
 
-    if (candidate.role === "tool") {
-      return candidate;
+    if (candidate?.role === "user") {
+      lastUserIndex = index;
+    } else if (candidate?.role === "tool") {
+      lastToolIndex = index;
     }
   }
 
-  for (let index = prompt.length - 1; index >= 0; index -= 1) {
-    const candidate = prompt[index];
+  if (lastUserIndex > lastToolIndex && lastUserIndex >= 0) {
+    return prompt[lastUserIndex] ?? null;
+  }
 
-    if (candidate.role === "user") {
-      return candidate;
-    }
+  if (lastToolIndex >= 0) {
+    return prompt[lastToolIndex] ?? null;
   }
 
   return prompt.at(-1) ?? null;

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -20,6 +20,30 @@ import { DEFAULT_ONBOARDING_SUGGESTION } from "../constants";
 import { logWarning } from "@/lib/logging";
 import { logPlaywrightStreamDebug } from "@/lib/playwright-debug";
 
+function isStringFragment(fragment: unknown): fragment is string {
+  return typeof fragment === "string";
+}
+
+function hasTextFragment(fragment: unknown): fragment is { text: string } {
+  return (
+    fragment != null &&
+    typeof fragment === "object" &&
+    "text" in fragment &&
+    typeof (fragment as { text?: unknown }).text === "string"
+  );
+}
+
+function hasInputTextFragment(
+  fragment: unknown
+): fragment is { input_text: string } {
+  return (
+    fragment != null &&
+    typeof fragment === "object" &&
+    "input_text" in fragment &&
+    typeof (fragment as { input_text?: unknown }).input_text === "string"
+  );
+}
+
 type CreateOpenAI = typeof import("@ai-sdk/openai").createOpenAI;
 
 const DEFAULT_MAX_OUTPUT_TOKENS = 4_096;
@@ -355,30 +379,22 @@ function buildPlaywrightChunks({
         index,
         role: message?.role ?? "unknown",
         contentSummary: Array.isArray(message?.content)
-          ? message.content
+          ? (message.content as unknown[])
               .map((fragment) => {
                 if (fragment == null) {
                   return null;
                 }
 
-                if (typeof fragment === "string") {
+                if (isStringFragment(fragment)) {
                   return fragment.slice(0, 80);
                 }
 
-                if (
-                  typeof fragment === "object" &&
-                  "text" in fragment &&
-                  typeof (fragment as { text?: unknown }).text === "string"
-                ) {
-                  return (fragment as { text: string }).text.slice(0, 80);
+                if (hasTextFragment(fragment)) {
+                  return fragment.text.slice(0, 80);
                 }
 
-                if (
-                  typeof fragment === "object" &&
-                  "input_text" in fragment &&
-                  typeof (fragment as { input_text?: unknown }).input_text === "string"
-                ) {
-                  return (fragment as { input_text: string }).input_text.slice(0, 80);
+                if (hasInputTextFragment(fragment)) {
+                  return fragment.input_text.slice(0, 80);
                 }
 
                 return fragment;
@@ -406,30 +422,22 @@ function buildPlaywrightChunks({
     () => ({
       role: recentMessage.role,
       contentSummary: Array.isArray(recentMessage.content)
-        ? recentMessage.content
+        ? (recentMessage.content as unknown[])
             .map((fragment) => {
               if (fragment == null) {
                 return null;
               }
 
-              if (typeof fragment === "string") {
+              if (isStringFragment(fragment)) {
                 return fragment.slice(0, 80);
               }
 
-              if (
-                typeof fragment === "object" &&
-                "text" in fragment &&
-                typeof (fragment as { text?: unknown }).text === "string"
-              ) {
-                return (fragment as { text: string }).text.slice(0, 80);
+              if (hasTextFragment(fragment)) {
+                return fragment.text.slice(0, 80);
               }
 
-              if (
-                typeof fragment === "object" &&
-                "input_text" in fragment &&
-                typeof (fragment as { input_text?: unknown }).input_text === "string"
-              ) {
-                return (fragment as { input_text: string }).input_text.slice(0, 80);
+              if (hasInputTextFragment(fragment)) {
+                return fragment.input_text.slice(0, 80);
               }
 
               return fragment;

--- a/lib/chat/message-identifiers.ts
+++ b/lib/chat/message-identifiers.ts
@@ -1,0 +1,205 @@
+import type { ChatMessage } from "@/lib/types";
+
+/**
+ * Describe a message that required a synthetic identifier so the UI state can
+ * remain stable while the upstream SDK omits an `id` property.
+ */
+export type IdentifierPatch = {
+  index: number;
+  fallbackId: string;
+  role: ChatMessage["role"] | undefined;
+};
+
+export type NormalisedIdentifiersResult = {
+  messages: ChatMessage[];
+  patches: IdentifierPatch[];
+  /**
+   * Flag indicating whether the helper had to materialise a brand-new array
+   * because the upstream message objects were non-extensible. Callers can use
+   * this signal to decide whether they should preserve the original array
+   * reference (by cloning it themselves) or reuse the pre-cloned collection
+   * returned here.
+   */
+  clonedArray: boolean;
+};
+
+/**
+ * Resolve a stable identifier for the provided message. Whenever the upstream
+ * payload already exposes a non-empty `id` we reuse it verbatim; otherwise we
+ * synthesise a deterministic fallback based on the chat id, the message index
+ * and the creation timestamp exposed through the metadata.
+ */
+export function resolveStableMessageId({
+  chatId,
+  index,
+  message,
+}: {
+  chatId: string;
+  index: number;
+  message: ChatMessage | null | undefined;
+}): { id: string; isSynthetic: boolean } {
+  const hasStableId =
+    typeof message?.id === "string" && message.id.trim().length > 0;
+
+  if (hasStableId && message) {
+    return { id: message.id, isSynthetic: false };
+  }
+
+  /**
+   * Some streamed payloads omit the metadata block altogether until the server
+   * persists the final message. Access it defensively so a missing
+   * `createdAt` timestamp results in a deterministic placeholder instead of a
+   * runtime TypeError that would collapse the entire chat surface.
+   */
+  const rawMetadata =
+    message && typeof message === "object"
+      ? (message as { metadata?: unknown }).metadata
+      : undefined;
+
+  let createdAt = "unknown";
+
+  if (rawMetadata && typeof rawMetadata === "object") {
+    const maybeCreatedAt = (rawMetadata as { createdAt?: unknown }).createdAt;
+
+    if (typeof maybeCreatedAt === "string" && maybeCreatedAt.trim().length > 0) {
+      createdAt = maybeCreatedAt;
+    }
+  }
+
+  return {
+    id: `${chatId}-synthetic-${index}-${createdAt}`,
+    isSynthetic: true,
+  };
+}
+
+/**
+ * Ensure every message in the provided collection exposes a stable identifier.
+ * The helper keeps the original array untouched when all entries already have
+ * an `id`, but returns a cloned array – and patch diagnostics – whenever a
+ * synthetic value had to be generated.
+ */
+export function normaliseMessageIdentifiers({
+  chatId,
+  messages,
+}: {
+  chatId: string;
+  messages: ChatMessage[] | null | undefined;
+}): NormalisedIdentifiersResult {
+  if (!Array.isArray(messages) || messages.length === 0) {
+    return {
+      messages: Array.isArray(messages) ? messages : [],
+      patches: [],
+      clonedArray: false,
+    };
+  }
+
+  let mutated = false;
+  let clonedArray: ChatMessage[] | null = null;
+  const patches: IdentifierPatch[] = [];
+
+  const ensureClonedArray = (): ChatMessage[] => {
+    if (clonedArray) {
+      return clonedArray;
+    }
+
+    clonedArray = [...(messages as ChatMessage[])];
+    return clonedArray;
+  };
+
+  for (let index = 0; index < messages.length; index += 1) {
+    const message = messages[index];
+    const { id, isSynthetic } = resolveStableMessageId({
+      chatId,
+      index,
+      message,
+    });
+
+    if (isSynthetic) {
+      mutated = true;
+      patches.push({ index, fallbackId: id, role: message?.role });
+
+      if (message && typeof message === "object") {
+        try {
+          Object.assign(message as ChatMessage, { id });
+          if (clonedArray) {
+            clonedArray[index] = message as ChatMessage;
+          }
+          continue;
+        } catch (error) {
+          const snapshot = ensureClonedArray();
+          snapshot[index] = { ...(message as ChatMessage), id };
+          continue;
+        }
+      } else {
+        ensureClonedArray();
+      }
+    }
+
+    if (clonedArray) {
+      clonedArray[index] = message as ChatMessage;
+    }
+  }
+
+  if (!mutated) {
+    return { messages: messages as ChatMessage[], patches, clonedArray: false };
+  }
+
+  if (!clonedArray) {
+    return { messages: messages as ChatMessage[], patches, clonedArray: false };
+  }
+
+  return { messages: clonedArray, patches, clonedArray: true };
+}
+
+export type PreparedIdentifierNormalisation = {
+  /**
+   * The next message collection that should replace the existing chat state.
+   * The array is always safe to reuse directly when a clone was required or
+   * re-created when mutations happened in place so React observers receive a
+   * fresh reference.
+   */
+  messages: ChatMessage[];
+  /**
+   * Collection of the identifier patches applied while normalising the
+   * messages. Callers can surface these diagnostics once the state has been
+   * updated so end-to-end tooling understands why synthetic identifiers were
+   * introduced.
+   */
+  patches: IdentifierPatch[];
+};
+
+/**
+ * Prepare a safe message collection ready to be committed back into the chat
+ * state. The helper acts as a thin wrapper around `normaliseMessageIdentifiers`
+ * but guarantees that callers always receive a fresh array reference when the
+ * upstream payload was mutated in place. Returning `null` keeps the updater
+ * short-circuiting friendly so state setters can bail out without triggering
+ * redundant renders.
+ */
+export function prepareNormalisedMessageUpdate({
+  chatId,
+  messages,
+}: {
+  chatId: string;
+  messages: ChatMessage[] | null | undefined;
+}): PreparedIdentifierNormalisation | null {
+  if (!Array.isArray(messages) || messages.length === 0) {
+    return null;
+  }
+
+  const { messages: normalisedMessages, patches, clonedArray } =
+    normaliseMessageIdentifiers({
+      chatId,
+      messages,
+    });
+
+  if (patches.length === 0) {
+    return null;
+  }
+
+  const nextMessages = clonedArray
+    ? normalisedMessages
+    : [...normalisedMessages];
+
+  return { messages: nextMessages, patches };
+}

--- a/lib/chat/message-identifiers.ts
+++ b/lib/chat/message-identifiers.ts
@@ -122,7 +122,7 @@ export function normaliseMessageIdentifiers({
         try {
           Object.assign(message as ChatMessage, { id });
           if (clonedArray) {
-            clonedArray[index] = message as ChatMessage;
+            ensureClonedArray()[index] = message as ChatMessage;
           }
           continue;
         } catch (error) {
@@ -136,7 +136,7 @@ export function normaliseMessageIdentifiers({
     }
 
     if (clonedArray) {
-      clonedArray[index] = message as ChatMessage;
+      ensureClonedArray()[index] = message as ChatMessage;
     }
   }
 

--- a/lib/chat/message-status.ts
+++ b/lib/chat/message-status.ts
@@ -1,0 +1,53 @@
+import type { UseChatHelpers } from "@ai-sdk/react";
+
+import type { ChatMessage } from "@/lib/types";
+
+/**
+ * Context required to derive the lifecycle attribute for a rendered message.
+ * The helper is deliberately independent from React so it can be unit-tested
+ * without mounting the chat surface.
+ */
+export type AssistantStatusComputation = {
+  /** Index of the message currently being rendered. */
+  index: number;
+  /** Index of the last assistant bubble currently visible. */
+  latestAssistantIndex: number;
+  /** Lifecycle reported by the chat transport (e.g. `"streaming"`). */
+  chatStatus: UseChatHelpers<ChatMessage>["status"];
+  /** Optional status already attached to the message by the SDK. */
+  messageStatus: ChatMessage["status"];
+  /** Role associated with the message (assistant, user, tool, …). */
+  role: ChatMessage["role"];
+};
+
+/**
+ * Compute the status that should be surfaced through `data-message-status` for
+ * the provided message.  Inline edit regenerations often reuse the existing
+ * assistant bubble which means the upstream SDK occasionally forgets to set the
+ * lifecycle back to `"streaming"`.  Falling back to a deterministic value keeps
+ * Playwright synchronisation stable while still honouring explicit statuses when
+ * they are provided.
+ */
+export function deriveAssistantMessageStatus({
+  index,
+  latestAssistantIndex,
+  chatStatus,
+  messageStatus,
+  role,
+}: AssistantStatusComputation): ChatMessage["status"] {
+  if (role !== "assistant") {
+    return messageStatus;
+  }
+
+  const isLatestAssistant = index === latestAssistantIndex;
+
+  if (chatStatus === "streaming" && isLatestAssistant) {
+    return "streaming";
+  }
+
+  if (messageStatus && messageStatus !== "streaming") {
+    return messageStatus;
+  }
+
+  return "completed";
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -85,11 +85,24 @@ export type CustomUIDataTypes = {
   financeScreen: FinanceScreenArtifact;
 };
 
+/**
+ * Lifecycle states that the Vercel AI SDK emits while streaming chat bubbles.
+ * The SDK currently toggles between well-known string literals such as
+ * `"streaming"` and `"completed"`, yet the surface is intentionally open so
+ * future releases can add more statuses (for tool-calling, hand-offs, …).
+ * Using a nominal string intersection preserves autocomplete for the existing
+ * states without preventing downstream callers from handling new values.
+ */
+export type ChatMessageStatus =
+  | "streaming"
+  | "completed"
+  | (string & {});
+
 export type ChatMessage = UIMessage<
   MessageMetadata,
   CustomUIDataTypes,
   ChatTools
->;
+> & { status?: ChatMessageStatus };
 
 export type Attachment = {
   name: string;

--- a/tests/setup/auth.setup.ts
+++ b/tests/setup/auth.setup.ts
@@ -10,6 +10,7 @@ import {
 } from "@playwright/test";
 
 import { hasAuthSessionCookie } from "../utils/auth-session";
+import { hasValidAuthSession } from "../utils/session-validation";
 import {
   clearPersistedSessionCookies,
   persistSessionCookies,
@@ -65,7 +66,7 @@ async function ensureLoggedIn(
    * avoid hitting the `/login` form and re-triggering a flurry of
    * `GET /api/auth/session` requests during hermetic runs.
    */
-  if (await hasExistingSession(context)) {
+  if (await hasExistingSession(context, baseURL)) {
     return;
   }
 
@@ -209,7 +210,9 @@ async function ensureLoggedIn(
     await Promise.all([waitForRedirect, signInButton.click()]);
 
     await expect
-      .poll(async () => hasExistingSession(context), { timeout: 15_000 })
+      .poll(async () => hasExistingSession(context, baseURL), {
+        timeout: 15_000,
+      })
       .toBeTruthy();
 
     await expect
@@ -275,8 +278,21 @@ async function ensureAutomationAccount(
   }
 }
 
-async function hasExistingSession(context: BrowserContext): Promise<boolean> {
-  return hasAuthSessionCookie(await context.cookies());
+async function hasExistingSession(
+  context: BrowserContext,
+  baseURL: string
+): Promise<boolean> {
+  return hasValidAuthSession({
+    readCookies: () => context.cookies(),
+    fetchSession: (url) =>
+      context.request.get(url, {
+        headers: { accept: "application/json" },
+      }),
+    baseURL,
+    logger: (message, details) => {
+      console.warn(message, details);
+    },
+  });
 }
 
 const getBaseURL = () =>
@@ -293,36 +309,48 @@ async function reuseStoredSession(browser: Browser, baseURL: string) {
     return false;
   }
 
-  const context = await browser.newContext({ storageState: STATE_PATH });
+  let context: BrowserContext | undefined;
 
   try {
-    const sessionResponse = await context.request.get(
-      `${baseURL}/api/auth/session`
-    );
+    const activeContext = await browser.newContext({ storageState: STATE_PATH });
 
-    if (!sessionResponse.ok()) {
+    // Conservez la référence pour le bloc `finally` tout en offrant au corps
+    // principal un alias non nullable que TypeScript peut suivre sans assertions.
+    context = activeContext;
+
+    const sessionIsValid = await hasValidAuthSession({
+      readCookies: () => activeContext.cookies(),
+      fetchSession: (url) =>
+        activeContext.request.get(url, {
+          headers: { accept: "application/json" },
+        }),
+      baseURL,
+      logger: (message, details) => {
+        console.warn(message, { ...details, scope: "reuseStoredSession" });
+      },
+    });
+
+    if (!sessionIsValid) {
       return false;
     }
 
-    const session: unknown = await sessionResponse.json();
-
-    if (
-      !session ||
-      typeof session !== "object" ||
-      !("user" in session) ||
-      !session.user ||
-      typeof session.user !== "object" ||
-      !("id" in session.user)
-    ) {
-      return false;
-    }
-
+    /**
+     * Refresh the persisted storage state so long-lived CI jobs keep extending
+     * the session expiration. The call mirrors the behaviour of the manual
+     * login flow which rewrites the snapshot after successfully authenticating
+     * the automation account.
+     */
     await context.storageState({ path: STATE_PATH });
     return true;
-  } catch {
+  } catch (error) {
+    console.warn("Failed to reuse stored Playwright session", {
+      cause: error instanceof Error ? error.message : String(error),
+    });
     return false;
   } finally {
-    await context.close();
+    if (context) {
+      await context.close();
+    }
   }
 }
 

--- a/tests/unit/ai/providers.spec.ts
+++ b/tests/unit/ai/providers.spec.ts
@@ -183,6 +183,57 @@ describe("ai provider configuration", () => {
     expect(aggregated).toContain("It's just blue duh!");
   });
 
+  it("prefers user prompts appended after tool responses", async () => {
+    process.env.PLAYWRIGHT = "true";
+    process.env.NEXT_PHASE = "phase-production-build";
+
+    const { myProvider } = await import("@/lib/ai/providers");
+    const chatModel = myProvider.languageModel("chat-model");
+
+    const prompt: ModelMessage[] = [
+      TEST_PROMPTS.USER_GRASS,
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "It's just green duh!" }],
+      },
+      {
+        /**
+         * Simulate the inline finance mocks returning a chart artefact before
+         * we submit a clarification. The regression caused the tool payload to
+         * overshadow the edited question.
+         */
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "call_finance_chart",
+            toolName: "tool.finance.chart.fetch",
+            output: { type: "json", value: { overlays: [] } },
+          },
+        ],
+      },
+      TEST_PROMPTS.USER_SKY,
+    ];
+
+    const { stream } = await chatModel.doStream({ prompt } as any);
+    const reader = stream.getReader();
+    let aggregated = "";
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+
+      const chunk = value as LanguageModelV2StreamPart | null;
+      if (chunk?.type === "text-delta") {
+        aggregated += String(chunk.delta ?? "");
+      }
+    }
+
+    expect(aggregated).toContain("It's just blue duh!");
+  });
+
   it("prefers the latest text fragment when edited prompts include multiple parts", async () => {
     process.env.PLAYWRIGHT = "true";
     process.env.NEXT_PHASE = "phase-production-build";

--- a/tests/unit/auth/actions.spec.ts
+++ b/tests/unit/auth/actions.spec.ts
@@ -2,6 +2,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { LoginActionState, RegisterActionState } from "@/app/(auth)/actions";
 
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
 vi.mock("@/app/(auth)/auth", () => ({
   signIn: vi.fn(),
 }));
@@ -14,13 +18,17 @@ vi.mock("@/lib/auth/sign-in-response", () => ({
 vi.mock("@/lib/db/queries", () => ({
   getUser: vi.fn(),
   createUser: vi.fn(),
+  createInitialChat: vi.fn(),
 }));
 
 const signIn = vi.mocked((await import("@/app/(auth)/auth")).signIn);
 const { didSignInSucceed, extractRedirectPath } = vi.mocked(
   await import("@/lib/auth/sign-in-response")
 );
-const { getUser, createUser } = vi.mocked(await import("@/lib/db/queries"));
+const { getUser, createUser, createInitialChat } = vi.mocked(
+  await import("@/lib/db/queries")
+);
+const { revalidatePath } = vi.mocked(await import("next/cache"));
 const { login, register } = await import("@/app/(auth)/actions");
 
 describe("auth actions", () => {
@@ -30,6 +38,13 @@ describe("auth actions", () => {
     extractRedirectPath.mockReturnValue(null);
     getUser.mockResolvedValue([undefined]);
     createUser.mockResolvedValue(undefined);
+    createInitialChat.mockResolvedValue({
+      chatId: "chat-123",
+      messageId: "message-123",
+      createdAt: new Date("2024-01-01T00:00:00.000Z"),
+      title: "Welcome",
+    });
+    revalidatePath.mockClear();
   });
 
   afterEach(() => {
@@ -61,5 +76,21 @@ describe("auth actions", () => {
       callbackUrl: "/chat",
     }));
     expect(result).toEqual({ status: "success", redirectTo: "/chat" });
+  });
+
+  it("seeds an onboarding chat and redirects to the seeded conversation when the user lookup succeeds", async () => {
+    const formData = new FormData();
+    formData.set("email", "fresh@example.com");
+    formData.set("password", "S3cure!");
+
+    getUser.mockResolvedValueOnce([undefined as any]);
+    getUser.mockResolvedValueOnce([{ id: "user-id" }] as any);
+
+    const result = await register({ status: "idle" } satisfies RegisterActionState, formData);
+
+    expect(createInitialChat).toHaveBeenCalledWith({ userId: "user-id" });
+    expect(revalidatePath).toHaveBeenCalledWith("/chat");
+    expect(revalidatePath).toHaveBeenCalledWith("/chat/chat-123");
+    expect(result).toEqual({ status: "success", redirectTo: "/chat/chat-123" });
   });
 });

--- a/tests/unit/components/chat.spec.tsx
+++ b/tests/unit/components/chat.spec.tsx
@@ -471,13 +471,15 @@ describe("Chat", () => {
       { wrapper: Wrapper }
     );
 
-    expect(logPlaywrightStreamDebugMock).toHaveBeenCalledWith(
-      "chat-component",
-      "status-change",
-      expect.any(Function)
+    expect(logPlaywrightStreamDebugMock).toHaveBeenCalled();
+
+    const statusCall = logPlaywrightStreamDebugMock.mock.calls.find(
+      ([scope, event]) => scope === "chat-component" && event === "status-change"
     );
 
-    const payloadFactory = logPlaywrightStreamDebugMock.mock.calls.at(-1)?.[2];
+    expect(statusCall).toBeDefined();
+
+    const payloadFactory = statusCall?.[2];
     expect(typeof payloadFactory).toBe("function");
 
     const payload = payloadFactory?.();

--- a/tests/unit/components/message.finance.spec.tsx
+++ b/tests/unit/components/message.finance.spec.tsx
@@ -357,4 +357,34 @@ describe("PreviewMessage finance feature flag", () => {
       expect.objectContaining({ artifact: backtestArtifact })
     );
   });
+
+  it("expose l'état du streaming via l'attribut data attendu par Playwright", () => {
+    // Le status provient du SDK Vercel AI et pilote la synchronisation de nos
+    // tests de bout en bout. Le composant doit le refléter dans le DOM pour
+    // que les helpers Playwright puissent détecter les reprises de streaming.
+    const message: ChatMessage = {
+      ...createFinanceToolMessage(),
+      status: "streaming",
+    };
+
+    const { getByTestId } = render(
+      <DataStreamProvider>
+        <PreviewMessage
+          chatId="chat-42"
+          isLoading={false}
+          isReadonly={true}
+          message={message}
+          regenerate={noop as any}
+          requiresScrollPadding={false}
+          setMessages={noop as any}
+          vote={undefined}
+        />
+      </DataStreamProvider>
+    );
+
+    expect(getByTestId("message-assistant")).toHaveAttribute(
+      "data-message-status",
+      "streaming"
+    );
+  });
 });

--- a/tests/unit/components/messages.render.spec.tsx
+++ b/tests/unit/components/messages.render.spec.tsx
@@ -1,0 +1,147 @@
+import React from "react";
+import "@testing-library/jest-dom/vitest";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ChatMessage } from "@/lib/types";
+
+const logWarningMock = vi.fn();
+const logDebugMock = vi.fn();
+
+vi.mock("@/hooks/use-messages", () => ({
+  useMessages: () => ({
+    containerRef: { current: null },
+    endRef: { current: null },
+    isAtBottom: true,
+    scrollToBottom: vi.fn(),
+    hasSentMessage: false,
+  }),
+}));
+
+vi.mock("@/components/data-stream-provider", () => ({
+  useDataStream: () => undefined,
+}));
+
+vi.mock("@/lib/feature-flags", () => ({
+  isFinanceFeatureEnabledClient: vi.fn(() => false),
+}));
+
+vi.mock("@/lib/logging", () => ({
+  logWarning: (...args: Parameters<typeof logWarningMock>) =>
+    logWarningMock(...args),
+}));
+
+vi.mock("@/lib/playwright-debug", () => ({
+  logPlaywrightStreamDebug: (...args: Parameters<typeof logDebugMock>) =>
+    logDebugMock(...args),
+}));
+
+vi.mock("@/components/message", () => ({
+  PreviewMessage: ({
+    message,
+  }: {
+    message: ChatMessage;
+  }) => (
+    <div
+      data-testid={`message-${message.role}`}
+      data-parts-length={message.parts.length}
+    />
+  ),
+  ThinkingMessage: () => <div data-testid="thinking-message" />,
+}));
+
+vi.mock("@/components/greeting", () => ({
+  Greeting: () => <div data-testid="greeting" />,
+}));
+
+vi.mock("@/components/elements/conversation", () => ({
+  Conversation: ({ children }: { children?: React.ReactNode }) => (
+    <div data-testid="conversation">{children}</div>
+  ),
+  ConversationContent: ({ children }: { children?: React.ReactNode }) => (
+    <div data-testid="conversation-content">{children}</div>
+  ),
+}));
+
+const noop = () => {};
+
+describe("Messages", () => {
+  beforeEach(() => {
+    logWarningMock.mockClear();
+    logDebugMock.mockClear();
+  });
+
+  it("renders assistant replies even when the SDK omits the parts array", () => {
+    const assistantWithoutParts = {
+      id: "assistant-1",
+      role: "assistant",
+      metadata: { createdAt: new Date().toISOString() },
+      parts: undefined,
+    } as unknown as ChatMessage;
+
+    render(
+      <React.Suspense fallback={null}>
+        <Messages
+          chatId="chat-1"
+          isArtifactVisible={false}
+          isReadonly={false}
+          messages={[assistantWithoutParts]}
+          regenerate={noop as any}
+          selectedModelId="chat-model"
+          setMessages={noop as any}
+          status="ready"
+          votes={[]}
+        />
+      </React.Suspense>
+    );
+
+    const assistant = screen.getByTestId("message-assistant");
+    expect(assistant).toBeInTheDocument();
+    expect(assistant).toHaveAttribute("data-parts-length", "0");
+
+    expect(logWarningMock).toHaveBeenCalledWith(
+      "chat:messages",
+      "[Messages] message arrived without a parts array; defaulting to empty",
+      expect.objectContaining({ messageId: "assistant-1", role: "assistant" })
+    );
+    expect(screen.queryByTestId("chat-message-fallback")).toBeNull();
+  });
+
+  it("synthesises a fallback identifier when the message id is missing", () => {
+    const createdAt = new Date().toISOString();
+    const assistantWithoutId = {
+      role: "assistant",
+      metadata: { createdAt },
+      parts: [{ type: "text", text: "Hello" }],
+    } as unknown as ChatMessage;
+
+    render(
+      <React.Suspense fallback={null}>
+        <Messages
+          chatId="chat-2"
+          isArtifactVisible={false}
+          isReadonly={false}
+          messages={[assistantWithoutId]}
+          regenerate={noop as any}
+          selectedModelId="chat-model"
+          setMessages={noop as any}
+          status="ready"
+          votes={[]}
+        />
+      </React.Suspense>
+    );
+
+    expect(screen.getByTestId("message-assistant")).toBeInTheDocument();
+    expect(logWarningMock).toHaveBeenCalledWith(
+      "chat:messages",
+      "[Messages] message arrived without a stable id; synthesising fallback",
+      expect.objectContaining({
+        chatId: "chat-2",
+        fallbackMessageId: `chat-2-synthetic-0-${createdAt}`,
+        role: "assistant",
+      })
+    );
+  });
+});
+
+const { Messages } = await import("@/components/messages");

--- a/tests/unit/components/messages.status.spec.ts
+++ b/tests/unit/components/messages.status.spec.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  deriveAssistantMessageStatus,
+  type AssistantStatusComputation,
+} from "@/lib/chat/message-status";
+
+describe("deriveAssistantMessageStatus", () => {
+  const baseContext: Omit<AssistantStatusComputation, "index" | "messageStatus" | "role"> & {
+    role?: AssistantStatusComputation["role"];
+  } = {
+    latestAssistantIndex: 2,
+    chatStatus: "ready",
+  };
+
+  it("forces the latest assistant bubble to streaming when the chat is streaming", () => {
+    const status = deriveAssistantMessageStatus({
+      index: 2,
+      latestAssistantIndex: baseContext.latestAssistantIndex,
+      chatStatus: "streaming",
+      messageStatus: "completed",
+      role: "assistant",
+    });
+
+    expect(status).toBe("streaming");
+  });
+
+  it("defaults to completed when the SDK omits a status", () => {
+    const status = deriveAssistantMessageStatus({
+      index: 1,
+      latestAssistantIndex: baseContext.latestAssistantIndex,
+      chatStatus: baseContext.chatStatus,
+      messageStatus: undefined,
+      role: "assistant",
+    });
+
+    expect(status).toBe("completed");
+  });
+
+  it("preserves explicit non-streaming statuses provided by the SDK", () => {
+    const status = deriveAssistantMessageStatus({
+      index: 0,
+      latestAssistantIndex: baseContext.latestAssistantIndex,
+      chatStatus: baseContext.chatStatus,
+      messageStatus: "in_progress",
+      role: "assistant",
+    });
+
+    expect(status).toBe("in_progress");
+  });
+
+  it("returns the original status for non-assistant messages", () => {
+    const status = deriveAssistantMessageStatus({
+      index: 0,
+      latestAssistantIndex: baseContext.latestAssistantIndex,
+      chatStatus: baseContext.chatStatus,
+      messageStatus: undefined,
+      role: "user",
+    });
+
+    expect(status).toBeUndefined();
+  });
+
+  it("resets lingering streaming statuses to completed once the chat is idle", () => {
+    const status = deriveAssistantMessageStatus({
+      index: 2,
+      latestAssistantIndex: baseContext.latestAssistantIndex,
+      chatStatus: baseContext.chatStatus,
+      messageStatus: "streaming",
+      role: "assistant",
+    });
+
+    expect(status).toBe("completed");
+  });
+});

--- a/tests/unit/lib/chat.message-identifiers.spec.ts
+++ b/tests/unit/lib/chat.message-identifiers.spec.ts
@@ -1,0 +1,231 @@
+import { describe, expect, it } from "vitest";
+
+import type { ChatMessage } from "@/lib/types";
+import {
+  normaliseMessageIdentifiers,
+  prepareNormalisedMessageUpdate,
+  resolveStableMessageId,
+} from "@/lib/chat/message-identifiers";
+
+describe("message identifier normalisation", () => {
+  it("reuses the provided identifier when present", () => {
+    const message = {
+      id: "assistant-123",
+      role: "assistant",
+      metadata: { createdAt: new Date().toISOString() },
+      parts: [],
+    } as unknown as ChatMessage;
+
+    const { id, isSynthetic } = resolveStableMessageId({
+      chatId: "chat-1",
+      index: 0,
+      message,
+    });
+
+    expect(id).toBe("assistant-123");
+    expect(isSynthetic).toBe(false);
+  });
+
+  it("synthesises a deterministic identifier when missing", () => {
+    const createdAt = "2025-12-11T00:00:00.000Z";
+    const message = {
+      role: "assistant",
+      metadata: { createdAt },
+      parts: [],
+    } as unknown as ChatMessage;
+
+    const { id, isSynthetic } = resolveStableMessageId({
+      chatId: "chat-42",
+      index: 3,
+      message,
+    });
+
+    expect(id).toBe(`chat-42-synthetic-3-${createdAt}`);
+    expect(isSynthetic).toBe(true);
+  });
+
+  it("falls back to an unknown timestamp when metadata is absent", () => {
+    const message = {
+      role: "assistant",
+      parts: [{ type: "text", text: "Hello" }],
+    } as unknown as ChatMessage;
+
+    const { id, isSynthetic } = resolveStableMessageId({
+      chatId: "chat-7",
+      index: 1,
+      message,
+    });
+
+    expect(id).toBe("chat-7-synthetic-1-unknown");
+    expect(isSynthetic).toBe(true);
+  });
+
+  it("patches assistant messages without identifiers", () => {
+    const createdAt = "2025-12-11T00:00:00.000Z";
+    const messages = [
+      {
+        role: "assistant",
+        metadata: { createdAt },
+        parts: [],
+      },
+      {
+        id: "user-1",
+        role: "user",
+        metadata: { createdAt },
+        parts: [],
+      },
+    ] as unknown as ChatMessage[];
+
+    const { messages: patched, patches, clonedArray } = normaliseMessageIdentifiers({
+      chatId: "chat-99",
+      messages,
+    });
+
+    expect(patches).toEqual([
+      {
+        fallbackId: "chat-99-synthetic-0-2025-12-11T00:00:00.000Z",
+        index: 0,
+        role: "assistant",
+      },
+    ]);
+
+    expect(patched[0]?.id).toBe(
+      "chat-99-synthetic-0-2025-12-11T00:00:00.000Z",
+    );
+    expect(patched[1]?.id).toBe("user-1");
+    expect(clonedArray).toBe(false);
+  });
+
+  it("returns the original array when all identifiers are present", () => {
+    const messages = [
+      {
+        id: "assistant-1",
+        role: "assistant",
+        metadata: { createdAt: new Date().toISOString() },
+        parts: [],
+      },
+    ] as unknown as ChatMessage[];
+
+    const result = normaliseMessageIdentifiers({
+      chatId: "chat-7",
+      messages,
+    });
+
+    expect(result.messages).toBe(messages);
+    expect(result.patches).toHaveLength(0);
+    expect(result.clonedArray).toBe(false);
+  });
+
+  it("clones the array when messages are non-extensible", () => {
+    const createdAt = new Date("2025-12-11T00:00:00.000Z").toISOString();
+    const frozenAssistant = Object.freeze({
+      role: "assistant",
+      metadata: { createdAt },
+      parts: [],
+    });
+
+    const messages = [
+      frozenAssistant,
+      {
+        id: "user-1",
+        role: "user",
+        metadata: { createdAt },
+        parts: [],
+      },
+    ] as unknown as ChatMessage[];
+
+    const { messages: patched, patches, clonedArray } = normaliseMessageIdentifiers({
+      chatId: "chat-123",
+      messages,
+    });
+
+    expect(clonedArray).toBe(true);
+    expect(patches).toHaveLength(1);
+    expect(patched).not.toBe(messages);
+    expect(patched[0]?.id).toBe(`chat-123-synthetic-0-${createdAt}`);
+    expect(patched[1]?.id).toBe("user-1");
+  });
+
+  it("prepares an updated collection when identifiers are missing", () => {
+    const createdAt = "2025-12-12T00:00:00.000Z";
+    const assistant = {
+      role: "assistant",
+      metadata: { createdAt },
+      parts: [],
+    } as unknown as ChatMessage;
+
+    const inputMessages = [assistant] as ChatMessage[];
+
+    const prepared = prepareNormalisedMessageUpdate({
+      chatId: "chat-prepare",
+      messages: inputMessages,
+    });
+
+    expect(prepared).not.toBeNull();
+    expect(prepared?.messages).not.toBeNull();
+    expect(prepared?.patches).toEqual([
+      {
+        fallbackId: "chat-prepare-synthetic-0-2025-12-12T00:00:00.000Z",
+        index: 0,
+        role: "assistant",
+      },
+    ]);
+
+    expect(prepared?.messages).not.toBe(inputMessages);
+    expect(prepared?.messages[0]?.id).toBe(
+      "chat-prepare-synthetic-0-2025-12-12T00:00:00.000Z",
+    );
+  });
+
+  it("returns null when every message already has a stable identifier", () => {
+    const messages = [
+      {
+        id: "assistant-existing",
+        role: "assistant",
+        metadata: { createdAt: new Date().toISOString() },
+        parts: [],
+      },
+    ] as unknown as ChatMessage[];
+
+    const prepared = prepareNormalisedMessageUpdate({
+      chatId: "chat-existing",
+      messages,
+    });
+
+    expect(prepared).toBeNull();
+  });
+
+  it("retains newer entries when normalising streamed messages", () => {
+    const createdAt = "2025-12-13T00:00:00.000Z";
+    const messages = [
+      {
+        id: "user-1",
+        role: "user",
+        metadata: { createdAt },
+        parts: [],
+      },
+      {
+        role: "assistant",
+        metadata: { createdAt },
+        parts: [],
+      },
+      {
+        id: "assistant-2",
+        role: "assistant",
+        metadata: { createdAt },
+        parts: [{ type: "text", text: "Most recent" }],
+      },
+    ] as unknown as ChatMessage[];
+
+    const prepared = prepareNormalisedMessageUpdate({
+      chatId: "chat-stream",
+      messages,
+    });
+
+    expect(prepared).not.toBeNull();
+    expect(prepared?.messages).toHaveLength(3);
+    expect(prepared?.messages[1]?.id).toBe("chat-stream-synthetic-1-2025-12-13T00:00:00.000Z");
+    expect(prepared?.messages[2]?.id).toBe("assistant-2");
+    expect(prepared?.messages[2]?.parts?.[0]?.text).toBe("Most recent");
+  });
+});

--- a/tests/unit/utils/session-validation.spec.ts
+++ b/tests/unit/utils/session-validation.spec.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { hasValidAuthSession } from "@/tests/utils/session-validation";
+
+const BASE_URL = "http://localhost:3100";
+
+/** Utility helper to build a stub response returned by the session fetcher. */
+function createSessionResponse(
+  overrides: Partial<{
+    ok: () => boolean;
+    status: () => number;
+    json: () => Promise<unknown>;
+    text: () => Promise<string>;
+  }> = {},
+) {
+  return {
+    ok: () => true,
+    status: () => 200,
+    json: async () => ({ user: { id: "user-id" } }),
+    text: async () => "",
+    ...overrides,
+  } satisfies Parameters<typeof hasValidAuthSession>[0]["fetchSession"] extends (
+    url: string,
+  ) => infer Response
+    ? Response
+    : never;
+}
+
+describe("hasValidAuthSession", () => {
+  it("returns false when the context does not hold an auth cookie", async () => {
+    const readCookies = vi.fn().mockResolvedValue([{ name: "other" }]);
+    const fetchSession = vi.fn();
+
+    const result = await hasValidAuthSession({
+      readCookies,
+      fetchSession,
+      baseURL: BASE_URL,
+    });
+
+    expect(result).toBe(false);
+    expect(fetchSession).not.toHaveBeenCalled();
+  });
+
+  it("returns false when the session endpoint rejects the request", async () => {
+    const readCookies = vi
+      .fn()
+      .mockResolvedValue([{ name: "authjs.session-token" }]);
+    const fetchSession = vi
+      .fn()
+      .mockResolvedValue(
+        createSessionResponse({
+          ok: () => false,
+          status: () => 401,
+          text: async () => "Unauthorized",
+        }),
+      );
+    const logger = vi.fn();
+
+    const result = await hasValidAuthSession({
+      readCookies,
+      fetchSession,
+      baseURL: BASE_URL,
+      logger,
+    });
+
+    expect(result).toBe(false);
+    expect(fetchSession).toHaveBeenCalledTimes(1);
+    expect(logger).toHaveBeenCalledWith(
+      "Playwright session validation failed",
+      expect.objectContaining({
+        baseURL: BASE_URL,
+        status: 401,
+      })
+    );
+  });
+
+  it("returns false when the session payload cannot be parsed", async () => {
+    const readCookies = vi
+      .fn()
+      .mockResolvedValue([{ name: "next-auth.session-token" }]);
+    const fetchSession = vi
+      .fn()
+      .mockResolvedValue(
+        createSessionResponse({
+          json: async () => {
+            throw new Error("invalid json");
+          },
+        }),
+      );
+
+    await expect(
+      hasValidAuthSession({
+        readCookies,
+        fetchSession,
+        baseURL: BASE_URL,
+      }),
+    ).resolves.toBe(false);
+  });
+
+  it("returns false when the payload misses the user identifier", async () => {
+    const readCookies = vi
+      .fn()
+      .mockResolvedValue([{ name: "authjs.session-token" }]);
+    const fetchSession = vi
+      .fn()
+      .mockResolvedValue(
+        createSessionResponse({
+          json: async () => ({ user: {} }),
+        }),
+      );
+
+    const result = await hasValidAuthSession({
+      readCookies,
+      fetchSession,
+      baseURL: BASE_URL,
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it("returns true when the session endpoint responds with a valid payload", async () => {
+    const readCookies = vi
+      .fn()
+      .mockResolvedValue([{ name: "next-auth.session-token" }]);
+    const fetchSession = vi
+      .fn()
+      .mockResolvedValue(createSessionResponse());
+
+    const result = await hasValidAuthSession({
+      readCookies,
+      fetchSession,
+      baseURL: BASE_URL,
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it("returns false and logs when the base URL cannot be parsed", async () => {
+    const readCookies = vi
+      .fn()
+      .mockResolvedValue([{ name: "next-auth.session-token" }]);
+    const fetchSession = vi.fn();
+    const logger = vi.fn();
+
+    const result = await hasValidAuthSession({
+      readCookies,
+      fetchSession,
+      baseURL: "invalid-base-url",
+      logger,
+    });
+
+    expect(result).toBe(false);
+    expect(fetchSession).not.toHaveBeenCalled();
+    expect(logger).toHaveBeenCalledWith(
+      "Failed to construct session validation endpoint",
+      expect.objectContaining({ baseURL: "invalid-base-url" })
+    );
+  });
+});

--- a/tests/utils/session-validation.ts
+++ b/tests/utils/session-validation.ts
@@ -1,0 +1,139 @@
+import { hasAuthSessionCookie } from "./auth-session";
+
+import type { Cookie } from "@playwright/test";
+
+/**
+ * Shape of the minimal response wrapper returned by Playwright's request API.
+ * Isolated here so the validation helper can remain fully typed while still
+ * being easy to stub inside the unit tests.
+ */
+type SessionResponse = {
+  ok(): boolean;
+  status(): number;
+  json(): Promise<unknown>;
+  text(): Promise<string>;
+};
+
+/**
+ * Dependencies required to validate whether a Playwright browser context still
+ * holds a usable Auth.js session. Calling code provides the cookie reader and
+ * the session fetcher so the helper can stay agnostic of the underlying
+ * Playwright primitives, which keeps the logic straightforward to unit test.
+ */
+type SessionValidationOptions = {
+  /** Function used to read the cookies currently attached to the context. */
+  readCookies: () => Promise<Array<Pick<Cookie, "name">>>;
+  /**
+   * Callback used to retrieve the JSON payload returned by
+   * `/api/auth/session`. The helper requests the endpoint using the provided
+   * base URL and aborts early when the response signals an error.
+   */
+  fetchSession: (url: string) => Promise<SessionResponse>;
+  /** Base URL of the running dev server (e.g. `http://localhost:3100`). */
+  baseURL: string;
+  /** Optional logger surfaced so callers can persist diagnostic metadata. */
+  logger?: (message: string, context?: Record<string, unknown>) => void;
+};
+
+/**
+ * Determine whether the persisted Playwright session cookie is still valid.
+ *
+ * The helper first checks for the presence of the Auth.js cookie. When the
+ * token exists we synchronously query `/api/auth/session` to ensure the server
+ * can decrypt the payload with the current secret. Any mismatch (expired token,
+ * rotated secret, malformed JSON) results in `false` so the global setup can
+ * proactively discard the stale cookie and trigger a fresh login.
+ */
+export async function hasValidAuthSession({
+  readCookies,
+  fetchSession,
+  baseURL,
+  logger,
+}: SessionValidationOptions): Promise<boolean> {
+  const cookies = await readCookies();
+
+  if (!hasAuthSessionCookie(cookies)) {
+    return false;
+  }
+
+  let sessionEndpoint: string;
+
+  try {
+    /**
+     * Guard against invalid environment configuration (such as `baseURL`
+     * missing the protocol) so the validation helper fails gracefully instead
+     * of throwing and crashing the Playwright global setup.
+     */
+    sessionEndpoint = new URL("/api/auth/session", baseURL).toString();
+  } catch (error) {
+    logger?.("Failed to construct session validation endpoint", {
+      baseURL,
+      cause: error instanceof Error ? error.message : String(error),
+    });
+    return false;
+  }
+
+  try {
+    const response = await fetchSession(sessionEndpoint);
+
+    if (!response.ok()) {
+      const preview = await response
+        .text()
+        .then((body) => body.slice(0, 200))
+        .catch(() => "");
+
+      logger?.("Playwright session validation failed", {
+        baseURL,
+        status: response.status(),
+        preview,
+      });
+
+      return false;
+    }
+
+    let payload: unknown;
+    try {
+      payload = await response.json();
+    } catch (error) {
+      logger?.("Failed to parse /api/auth/session response", {
+        baseURL,
+        cause: error instanceof Error ? error.message : String(error),
+      });
+      return false;
+    }
+
+    if (!payload || typeof payload !== "object") {
+      logger?.("Playwright session payload missing user object", {
+        baseURL,
+        payload,
+      });
+      return false;
+    }
+
+    const user = (payload as { user?: unknown }).user;
+    if (!user || typeof user !== "object") {
+      logger?.("Playwright session payload missing user object", {
+        baseURL,
+        payload,
+      });
+      return false;
+    }
+
+    const identifier = (user as { id?: unknown }).id;
+    if (typeof identifier !== "string" || identifier.length === 0) {
+      logger?.("Playwright session payload missing user identifier", {
+        baseURL,
+        payload,
+      });
+      return false;
+    }
+
+    return true;
+  } catch (error) {
+    logger?.("Unexpected error while validating Playwright session", {
+      baseURL,
+      cause: error instanceof Error ? error.message : String(error),
+    });
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- funnel chat identifier normalisation through functional `setMessages` updates so streaming snapshots are not overwritten while we synthesise fallback ids
- expose a reusable `prepareNormalisedMessageUpdate` helper and extend the identifier suite to cover the cloned-array path and streamed follow-up messages
- refresh the agent brief with the new completion marker and note that Playwright now blocks on installing browsers before the focused chat rerun

## Testing
- node scripts/run-vitest.mjs tests/unit/lib/chat.message-identifiers.spec.ts
- PLAYWRIGHT_STREAM_DEBUG=1 pnpm exec playwright test tests/e2e/chat.test.ts -g "Send a user message and receive response" --workers=1 *(fails: Playwright browsers are not installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f5a20e7fb0832f8913b751987a3c09